### PR TITLE
fix: significantly improve the performance of /node-connections endpoint

### DIFF
--- a/packages/network/src/logic/OverlayTopology.ts
+++ b/packages/network/src/logic/OverlayTopology.ts
@@ -80,6 +80,10 @@ export class OverlayTopology {
         return Object.entries(this.nodes).length === 0
     }
 
+    getNodes(): TopologyNodes {
+        return this.nodes
+    }
+
     state(): TopologyState {
         const objects = Object.entries(this.nodes).map(([nodeId, neighbors]) => {
             return {

--- a/packages/network/src/logic/trackerSummaryUtils.ts
+++ b/packages/network/src/logic/trackerSummaryUtils.ts
@@ -43,9 +43,11 @@ export function getNodeConnections(nodes: readonly string[], overlayPerStream: O
     nodes.forEach((node) => {
         result[node] = new Set<string>()
     })
-    nodes.forEach((node) => {
-        Object.values(overlayPerStream).forEach((overlayTopology) => {
-            result[node] = new Set([...result[node], ...overlayTopology.getNeighbors(node)])
+    Object.values(overlayPerStream).forEach((overlayTopology) => {
+        Object.entries(overlayTopology.getNodes()).forEach(([nodeId, neighbors]) => {
+            neighbors.forEach((neighborNode) => {
+                result[nodeId].add(neighborNode)
+            })
         })
     })
     return result


### PR DESCRIPTION
- Run through the Overlay once only instead of n times (n = number of nodes)