### PR TITLE
Fairer isOffering logic

### DIFF
--- a/packages/network/src/connection/WebRtcConnection.ts
+++ b/packages/network/src/connection/WebRtcConnection.ts
@@ -51,7 +51,7 @@ export function isOffering(myId: PeerId, theirId: PeerId): boolean {
 
 function offeringHash(idPair: string): number {
     const buffer = crypto.createHash('md5').update(idPair).digest()
-    return buffer.readInt32LE(0)
+    return buffer.readInt32LE()
 }
 
 /**

--- a/packages/network/src/connection/WebRtcConnection.ts
+++ b/packages/network/src/connection/WebRtcConnection.ts
@@ -5,6 +5,7 @@ import { Logger } from '../helpers/Logger'
 import { PeerId, PeerInfo } from './PeerInfo'
 import { MessageQueue, QueueItem } from './MessageQueue'
 import { NameDirectory } from '../NameDirectory'
+import crypto from 'crypto'
 
 export interface ConstructorOptions {
     selfId: PeerId
@@ -45,7 +46,12 @@ interface Events {
 export const ConnectionEmitter = EventEmitter as { new(): StrictEventEmitter<EventEmitter, Events> }
 
 export function isOffering(myId: PeerId, theirId: PeerId): boolean {
-    return myId < theirId
+    return offeringHash(myId + theirId) < offeringHash(theirId + myId)
+}
+
+function offeringHash(idPair: string): number {
+    const buffer = crypto.createHash('md5').update(idPair).digest()
+    return buffer.readInt32LE(0)
 }
 
 /**

--- a/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -55,7 +55,10 @@ describe('WebRtcEndpoint: back pressure handling', () => {
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
         )
-        await ep1.connect('ep2', 'tracker')
+        await Promise.all([
+            ep1.connect('ep2', 'tracker'),
+            ep2.connect('ep1', 'tracker')
+        ])
     })
 
     afterEach(async () => {

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -303,7 +303,7 @@ describe('WebRtcEndpoint', () => {
                     endpoint1.close('node-2', 'test')
                 },
                 () => {
-                    endpoint1.connect('node-2', 'tracker')
+                    endpoint1.connect('node-2', 'tracker', false)
                 }], [
                 [endpoint1, EndpointEvent.PEER_CONNECTED],
                 [endpoint2, EndpointEvent.PEER_CONNECTED]
@@ -314,7 +314,7 @@ describe('WebRtcEndpoint', () => {
                     endpoint2.close('node-1', 'test')
                 },
                 () => {
-                    endpoint2.connect('node-1', 'tracker', false)
+                    endpoint2.connect('node-1', 'tracker')
                 }], [
                 [endpoint1, EndpointEvent.PEER_CONNECTED],
                 [endpoint2, EndpointEvent.PEER_CONNECTED]
@@ -398,7 +398,7 @@ describe('WebRtcEndpoint', () => {
             await Promise.all([
                 waitForEvent(endpoint1, EndpointEvent.PEER_CONNECTED),
                 waitForEvent(endpoint2, EndpointEvent.PEER_CONNECTED),
-                endpoint1.connect('node-2', 'tracker')
+                endpoint2.connect('node-1', 'tracker')
             ])
 
             let ep1NumOfReceivedMessages = 0
@@ -437,7 +437,7 @@ describe('WebRtcEndpoint', () => {
 
         it('cannot send too large of a payload', async () => {
             const payload = new Array(2 ** 21).fill('X').join('')
-            await endpoint1.connect('node-2', 'tracker')
+            await endpoint2.connect('node-1', 'tracker')
             await expect(async () => {
                 await endpoint1.send('node-2', payload)
             }).rejects.toThrow(/Dropping message due to size 2097152 exceeding the limit of \d+/)


### PR DESCRIPTION
- Concatenate nodeIds and and compare their hashes when selecting the offering peer for WebRTC
- This reduces the likelyhood of nodes always being an offerer or non-offerer if their nodeIds are too "high" or "low"