### PR TITLE
network: improve connection log messages

### DIFF
--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -124,20 +124,24 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     }
 
     private startConnectionStatusReport(): void {
+        const getPeerNameList = (peerIds: PeerId[]) => {
+            return peerIds.map((peerId) => NameDirectory.getName(peerId)).join(',')
+        }
         const STATUS_REPORT_INTERVAL_MS = 5 * 60 * 1000
         this.statusReportTimer = setInterval(() => {
-            let connectedPeerCount = 0
+            const connectedPeerIds = []
             const pendingPeerIds = []
             for (const peerId of Object.keys(this.connections)) {
                 const lastState = this.connections[peerId].getLastState()
                 if (lastState === 'connected') {
-                    connectedPeerCount += 1
+                    connectedPeerIds.push(peerId)
                 } else if (lastState === 'connecting') {
                     pendingPeerIds.push(peerId)
                 }
             }
-            this.logger.info(`Successfully connected to %d peers. Still trying to connect to the following peers: [%s]`,
-                connectedPeerCount, pendingPeerIds.join(', '))
+            const suffix = (pendingPeerIds.length > 0) ? ', still trying to connect: %s' : ''
+            this.logger.info(`Successfully connected to %d peers (%s)${suffix}`,
+                connectedPeerIds.length, getPeerNameList(connectedPeerIds), getPeerNameList(pendingPeerIds))
         }, STATUS_REPORT_INTERVAL_MS)
     }
 

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -5,6 +5,7 @@ import { Logger } from '../../helpers/Logger'
 import { PeerInfo } from '../../connection/PeerInfo'
 import { TrackerId } from '../tracker/Tracker'
 import { StreamManager } from './StreamManager'
+import { NameDirectory } from '../../NameDirectory'
 
 const logger = new Logger(module)
 
@@ -69,7 +70,7 @@ export class TrackerConnector {
         this.nodeToTracker.connectToTracker(ws, PeerInfo.newTracker(id))
             .then(() => {
                 if (this.connectionStates.get(id) !== ConnectionState.SUCCESS) {
-                    logger.info('Connected to tracker %s', id)
+                    logger.info('Connected to tracker %s', NameDirectory.getName(id))
                     this.connectionStates.set(id, ConnectionState.SUCCESS)
                 }
                 return
@@ -79,7 +80,7 @@ export class TrackerConnector {
                     // TODO we could also store the previous error and check that the current error is the same?
                     // -> now it doesn't log anything if the connection error reason changes
                     this.connectionStates.set(id, ConnectionState.ERROR)
-                    logger.warn('Could not connect to tracker %s, reason: %s', id, err.message)
+                    logger.warn('Could not connect to tracker %s, reason: %s', NameDirectory.getName(id), err.message)
                 }
             })
     }

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -9,6 +9,7 @@ import { NodeId } from './Node'
 import { InstructionThrottler } from './InstructionThrottler'
 import { InstructionRetryManager } from './InstructionRetryManager'
 import { Metrics } from '../../helpers/MetricsContext'
+import { NameDirectory } from '../../NameDirectory'
 
 const logger = new Logger(module)
 
@@ -192,12 +193,12 @@ export class TrackerManager {
         const subscribedNodeIds: NodeId[] = []
         const unsubscribedNodeIds: NodeId[] = []
         let failedInstructions = false
-        results.forEach((res) => {
+        results.forEach((res, i) => {
             if (res.status === 'fulfilled') {
                 subscribedNodeIds.push(res.value)
             } else {
                 failedInstructions = true
-                logger.info('failed to subscribe (or connect) to node, reason: %s', res.reason)
+                logger.debug('failed to subscribe (or connect) to %s, reason: %s', NameDirectory.getName(nodeIds[i]), res.reason)
             }
         })
         if (!reattempt || failedInstructions) {


### PR DESCRIPTION
Changed some log messages:

**1. Scheduled connectivity status**
`Successfully connected to 4 peers. Still trying to connect to the following peers: [0xD898eb0c0a2A6dF481a48fE9040A3bAE121Dd58a`
-> `Successfully connected to 2 peers (0x123456,0x234567), still trying to connect: 0x456789,0x567890`
or --> `Successfully connected to 4 peers (0x123456,0x234567,0x345679,0x4567890)`

**2. Failed connections**
`INFO failed to subscribe (or connect) to node, reason: ...`
-> `DEBUG failed to subscribe (or connect) to 0x123456, reason: ...`

**3. Tracker connections**
`TrackerConnector` logs `trackerIds` as short names (0x123456 instead of a full Ethereum address).