### PR TITLE
broker: function return types

### DIFF
--- a/packages/broker/.eslintrc
+++ b/packages/broker/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "eslint-config-streamr-ts",
   "rules": {
     "@typescript-eslint/ban-ts-comment": "warn",
-    "@typescript-eslint/explicit-module-boundary-types": "warn",
     "max-len": "warn",
     "no-underscore-dangle": "warn"
   }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -157,7 +157,7 @@ const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inq
         type: 'password',
         name:'importPrivateKey',
         message: 'Please provide the private key to import',
-        when: (answers: inquirer.Answers) => {
+        when: (answers: inquirer.Answers): boolean => {
             return answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT
         },
         validate: (input: string): string | boolean => {
@@ -174,7 +174,7 @@ const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inq
         name: 'revealGeneratedPrivateKey',
         message: 'We strongly recommend backing up your private key. It will be written into the config file, but would you also like to see this sensitive information on screen now?',
         default: false,
-        when: (answers: inquirer.Answers) => {
+        when: (answers: inquirer.Answers): boolean => {
             return answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_GENERATE
         }
     }
@@ -296,6 +296,7 @@ const selectStoragePath = async (): Promise<inquirer.Answers> => {
     return answers
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createStorageFile = async (config: any, answers: inquirer.Answers): Promise<string> => {
     if (!answers.parentDirExists) {
         mkdirSync(answers.parentDirPath)
@@ -310,7 +311,10 @@ export const getPrivateKey = (answers: inquirer.Answers): string => {
     return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT) ? answers.importPrivateKey : Wallet.createRandom().privateKey
 }
 
-export const getNodeIdentity = (privateKey: string) => {
+export const getNodeIdentity = (privateKey: string): {
+    mnemonic: string
+    networkExplorerUrl: string
+} => {
     const nodeAddress = new Wallet(privateKey).address
     const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
     const networkExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`

--- a/packages/broker/src/RequestAuthenticatorMiddleware.ts
+++ b/packages/broker/src/RequestAuthenticatorMiddleware.ts
@@ -8,6 +8,7 @@ const logger = new Logger(module)
 /**
  * Middleware used to authenticate REST API requests
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const authenticator = (streamFetcher: StreamFetcher, permission = 'stream_subscribe') => (req: Todo, res: Todo, next: Todo) => {
     let sessionToken
 

--- a/packages/broker/src/RequestAuthenticatorMiddleware.ts
+++ b/packages/broker/src/RequestAuthenticatorMiddleware.ts
@@ -1,4 +1,5 @@
 import { Todo } from './types'
+import { Request, Response, NextFunction } from 'express'
 import { HttpError } from './errors/HttpError'
 import { Logger } from 'streamr-network'
 import { StreamFetcher } from './StreamFetcher'
@@ -9,7 +10,7 @@ const logger = new Logger(module)
  * Middleware used to authenticate REST API requests
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const authenticator = (streamFetcher: StreamFetcher, permission = 'stream_subscribe') => (req: Todo, res: Todo, next: Todo) => {
+export const authenticator = (streamFetcher: StreamFetcher, permission = 'stream_subscribe') => (req: Request & { stream?: Todo }, res: Response, next: NextFunction) => {
     let sessionToken
 
     // Try to parse authorization header if defined

--- a/packages/broker/src/Stream.ts
+++ b/packages/broker/src/Stream.ts
@@ -1,12 +1,14 @@
 import { Todo } from './types'
 
-export class Stream {
+type State = 'init'|'subscribing'|'subscribed'
 
-    id: Todo
-    name: Todo
-    partition: Todo
-    state: Todo
-    connections: Todo
+export class Stream<C> {
+
+    id: string
+    name: string
+    partition: number
+    state: State
+    connections: C[]
 
     constructor(id: string, partition: number, name: string) {
         this.id = id
@@ -16,54 +18,54 @@ export class Stream {
         this.connections = []
     }
 
-    addConnection(connection: Todo) {
+    addConnection(connection: C): void {
         this.connections.push(connection)
     }
 
-    removeConnection(connection: Todo) {
+    removeConnection(connection: C): void {
         const index = this.connections.indexOf(connection)
         if (index > -1) {
             this.connections.splice(index, 1)
         }
     }
 
-    forEachConnection(cb: Todo) {
+    forEachConnection(cb: Todo): void {
         this.getConnections().forEach(cb)
     }
 
-    getConnections() {
+    getConnections(): C[] {
         return this.connections
     }
 
-    setSubscribing() {
+    setSubscribing(): void {
         this.state = 'subscribing'
     }
 
-    setSubscribed() {
+    setSubscribed(): void {
         this.state = 'subscribed'
     }
 
-    isSubscribing() {
+    isSubscribing(): boolean {
         return this.state === 'subscribing'
     }
 
-    isSubscribed() {
+    isSubscribed(): boolean {
         return this.state === 'subscribed'
     }
 
-    toString() {
+    toString(): string {
         return `${this.id}::${this.partition}`
     }
 
-    getName() {
+    getName(): string {
         return this.name
     }
 
-    getId() {
+    getId(): string {
         return this.id
     }
 
-    getPartition() {
+    getPartition(): number {
         return this.partition
     }
 }

--- a/packages/broker/src/errors/HttpError.ts
+++ b/packages/broker/src/errors/HttpError.ts
@@ -16,7 +16,7 @@ export class HttpError extends Error {
         this.url = url
     }
 
-    toString() {
+    toString(): string {
         return `HttpError ${this.method} ${this.url} responded with ${this.code}`
     }
 }

--- a/packages/broker/src/helpers/ConfigAutoMigrate.ts
+++ b/packages/broker/src/helpers/ConfigAutoMigrate.ts
@@ -80,6 +80,7 @@ const migrateTrackerRegistry = (trackerRegistry: TrackerRegistryItem[]): Tracker
     }
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const testnet2AutoMigrate = (config: any, configFilePath: string): Config => {
     // Skip auto-migration if testnetMiner plugin not enabled
     if (config.plugins.testnetMiner === undefined) {

--- a/packages/broker/src/helpers/PayloadFormat.ts
+++ b/packages/broker/src/helpers/PayloadFormat.ts
@@ -98,6 +98,6 @@ export class MetadataPayloadFormat implements PayloadFormat {
     }
 }
 
-export const getPayloadFormat = (metadata: boolean) => {
+export const getPayloadFormat = (metadata: boolean): PayloadFormat => {
     return metadata ? new MetadataPayloadFormat() : new PlainPayloadFormat()
 }

--- a/packages/broker/src/helpers/authentication.ts
+++ b/packages/broker/src/helpers/authentication.ts
@@ -1,6 +1,6 @@
 import { Headers } from 'node-fetch'
 
-export function formAuthorizationHeader(sessionToken: string | null | undefined): Headers {
+export const formAuthorizationHeader = (sessionToken: string | null | undefined): Headers => {
     const headers: Headers = new Headers()
     if (sessionToken) {
         headers.set('Authorization', `Bearer ${sessionToken}`)

--- a/packages/broker/src/helpers/closeWebsocket.ts
+++ b/packages/broker/src/helpers/closeWebsocket.ts
@@ -6,7 +6,7 @@ import Cutter from 'utf8-binary-cutter'
 const STATUS_UNEXPECTED_CONDITION = 1011
 const MAX_ERROR_MESSAGE_LENGTH = 123 // https://html.spec.whatwg.org/multipage/web-sockets.html
 
-export const closeWithError = (error: Error, context: string, ws: WebSocket, logger: Logger) => {
+export const closeWithError = (error: Error, context: string, ws: WebSocket, logger: Logger): void => {
     const msg = `${context}: ${error.message}`
     logger.error(msg, error)
     ws.close(STATUS_UNEXPECTED_CONDITION, Cutter.truncateToBinarySize(msg, MAX_ERROR_MESSAGE_LENGTH))

--- a/packages/broker/src/helpers/fetch.ts
+++ b/packages/broker/src/helpers/fetch.ts
@@ -1,6 +1,6 @@
 import fetch, { RequestInit, Response } from 'node-fetch'
 
-export const fetchOrThrow = async (url: string, init?: RequestInit): Promise<Response|never> => {
+export const fetchOrThrow = async (url: string, init?: RequestInit): Promise<Response> => {
     const res = await fetch(url, init)
     if (res.ok) {
         return res

--- a/packages/broker/src/helpers/fetch.ts
+++ b/packages/broker/src/helpers/fetch.ts
@@ -1,6 +1,6 @@
-import fetch, { RequestInit } from 'node-fetch'
+import fetch, { RequestInit, Response } from 'node-fetch'
 
-export const fetchOrThrow = async (url: string, init?: RequestInit) => {
+export const fetchOrThrow = async (url: string, init?: RequestInit): Promise<Response|never> => {
     const res = await fetch(url, init)
     if (res.ok) {
         return res

--- a/packages/broker/src/helpers/partition.ts
+++ b/packages/broker/src/helpers/partition.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 
-export const partition = (partitionCount: number, partitionKey = '') => {
+export const partition = (partitionCount: number, partitionKey = ''): number|never => {
     if (!partitionCount) {
         throw new Error('partitionCount is falsey!')
     } else if (partitionCount === 1) {

--- a/packages/broker/src/helpers/scheduler.ts
+++ b/packages/broker/src/helpers/scheduler.ts
@@ -38,7 +38,7 @@ export const scheduleAtInterval = async (
 export const scheduleAtFixedRate = (
     task: (now: number) => Promise<void>, 
     interval: number
-) => {
+): { stop: () => void }  => {
     let timer: NodeJS.Timer|undefined
     let stopRequested = false
     const scheduleNext = () => {

--- a/packages/broker/src/helpers/validateConfig.ts
+++ b/packages/broker/src/helpers/validateConfig.ts
@@ -2,7 +2,7 @@ import Ajv, { Schema } from 'ajv'
 import addFormats from 'ajv-formats'
 import { Todo } from '../types'
 
-export const validateConfig = (data: unknown, schema: Schema, contextName?: string) => {
+export const validateConfig = (data: unknown, schema: Schema, contextName?: string): void|never => {
     const ajv = new Ajv({
         useDefaults: true
     })

--- a/packages/broker/src/httpServer.ts
+++ b/packages/broker/src/httpServer.ts
@@ -36,7 +36,7 @@ const createAuthenticatorMiddleware = (apiAuthenticator: ApiAuthenticator) => {
     }
 }
 
-export const startServer = async (routers: express.Router[], config: HttpServerConfig, apiAuthenticator: ApiAuthenticator) => {
+export const startServer = async (routers: express.Router[], config: HttpServerConfig, apiAuthenticator: ApiAuthenticator): Promise<HttpServer|https.Server> => {
     const app = express()
     app.use(cors())
     app.use(createAuthenticatorMiddleware(apiAuthenticator))
@@ -56,7 +56,7 @@ export const startServer = async (routers: express.Router[], config: HttpServerC
     return server
 }
 
-export const stopServer = async (httpServer: HttpServer|HttpsServer) => {
+export const stopServer = async (httpServer: HttpServer|HttpsServer): Promise<void> => {
     if (httpServer.listening) {
         httpServer.close()
         await once(httpServer, 'close')

--- a/packages/broker/src/pluginRegistry.ts
+++ b/packages/broker/src/pluginRegistry.ts
@@ -1,4 +1,4 @@
-import { PluginOptions } from './Plugin'
+import { Plugin, PluginOptions } from './Plugin'
 import { PublishHttpPlugin } from './plugins/publishHttp/PublishHttpPlugin'
 import { PublishHttpPlugin as LegacyPublishHttpPlugin } from './plugins/legacyPublishHttp/PublishHttpPlugin'
 import { MetricsPlugin } from './plugins/metrics/MetricsPlugin'
@@ -9,7 +9,7 @@ import { MqttPlugin as LegacyMqttPlugin } from './plugins/legacyMqtt/MqttPlugin'
 import { StoragePlugin } from './plugins/storage/StoragePlugin'
 import { TestnetMinerPlugin } from './plugins/testnetMiner/TestnetMinerPlugin'
 
-export const createPlugin = (name: string, pluginOptions: PluginOptions) => {
+export const createPlugin = (name: string, pluginOptions: PluginOptions): Plugin<any>|never => {
     switch (name) {
         case 'publishHttp':
             return new PublishHttpPlugin(pluginOptions)

--- a/packages/broker/src/plugins/legacyMqtt/Connection.ts
+++ b/packages/broker/src/plugins/legacyMqtt/Connection.ts
@@ -33,34 +33,34 @@ export class Connection extends events.EventEmitter {
         this.client.on('pingreq', () => this.client.pingresp())
     }
 
-    markAsDead() {
+    markAsDead(): void {
         this.dead = true
     }
 
-    isDead() {
+    isDead(): any {
         return this.dead
     }
 
     // Connection refused, server unavailable
-    sendConnectionRefusedServerUnavailable() {
+    sendConnectionRefusedServerUnavailable(): void {
         this._sendConnack(3)
     }
 
     // Connection refused, bad user name or password
-    sendConnectionRefused() {
+    sendConnectionRefused(): void {
         this._sendConnack(4)
     }
 
     // Connection refused, not authorized
-    sendConnectionNotAuthorized() {
+    sendConnectionNotAuthorized(): void {
         this._sendConnack(5)
     }
 
-    sendConnectionAccepted() {
+    sendConnectionAccepted(): void {
         this._sendConnack(0)
     }
 
-    _sendConnack(code = 0) {
+    _sendConnack(code = 0): void {
         try {
             this.client.connack({
                 returnCode: code
@@ -70,7 +70,7 @@ export class Connection extends events.EventEmitter {
         }
     }
 
-    sendUnsubscribe(packet: Todo) {
+    sendUnsubscribe(packet: Todo): void {
         try {
             if (!this.isDead()) {
                 this.client.unsubscribe(packet)
@@ -80,17 +80,17 @@ export class Connection extends events.EventEmitter {
         }
     }
 
-    setClientId(clientId: Todo) {
+    setClientId(clientId: Todo): this {
         this.id = clientId
         return this
     }
 
-    setToken(token: Todo) {
+    setToken(token: Todo): this {
         this.token = token
         return this
     }
 
-    close() {
+    close(): void {
         try {
             this.client.destroy()
         } catch (e) {
@@ -100,26 +100,26 @@ export class Connection extends events.EventEmitter {
         this.streams = []
     }
 
-    addStream(stream: Todo) {
+    addStream(stream: Todo): void {
         this.streams.push(stream)
     }
 
-    removeStream(streamId: string, streamPartition: number) {
+    removeStream(streamId: string, streamPartition: number): void {
         const i = this.streams.findIndex((s: Todo) => s.id === streamId && s.partition === streamPartition)
         if (i !== -1) {
             this.streams.splice(i, 1)
         }
     }
 
-    forEachStream(cb: Todo) {
+    forEachStream(cb: Todo): void {
         this.getStreams().forEach(cb)
     }
 
-    getStreams() {
+    getStreams(): any {
         return this.streams.slice() // return copy
     }
 
-    streamsAsString() {
+    streamsAsString(): any {
         return this.streams.map((s: Todo) => s.toString())
     }
 }

--- a/packages/broker/src/plugins/legacyMqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttPlugin.ts
@@ -5,6 +5,7 @@ import { MqttServer } from './MqttServer'
 import { Plugin, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
+import { Schema } from 'ajv'
 
 const logger = new Logger(module)
 
@@ -21,7 +22,7 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         super(options)
     }
 
-    async start() {
+    async start(): Promise<void> {
         if (this.pluginConfig.port === undefined) {
             throw new MissingConfigError('port')
         }
@@ -39,11 +40,11 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         )
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         return this.mqttServer!.close()
     }
 
-    getConfigSchema() {
+    getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
@@ -51,7 +51,7 @@ export class MqttServer extends EventEmitter {
     partitionFn
     subscriptionManager: SubscriptionManager
     connections = new Set<Connection>()
-    streams: StreamStateManager
+    streams: StreamStateManager<Connection>
     metrics: Metrics
 
     constructor(

--- a/packages/broker/src/plugins/legacyPublishHttp/DataProduceEndpoints.ts
+++ b/packages/broker/src/plugins/legacyPublishHttp/DataProduceEndpoints.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { Router } from 'express'
 import bodyParser from 'body-parser'
 import { Protocol } from 'streamr-network'
 import { Logger } from 'streamr-network'
@@ -19,7 +19,7 @@ const { InvalidJsonError, ValidationError } = Protocol.Errors
 /**
  * Endpoint for POSTing data to streams
  */
-export const router = (streamFetcher: StreamFetcher, publisher: Publisher, partitionFn = partition) => {
+export const router = (streamFetcher: StreamFetcher, publisher: Publisher, partitionFn = partition): Router => {
     if (!streamFetcher) {
         throw new Error('No StreamFetcher given! Must use: new StreamrDataApi(streamrUrl)')
     }

--- a/packages/broker/src/plugins/legacyPublishHttp/PublishHttpPlugin.ts
+++ b/packages/broker/src/plugins/legacyPublishHttp/PublishHttpPlugin.ts
@@ -8,11 +8,11 @@ export class PublishHttpPlugin extends Plugin<void> {
         super(options)
     }
 
-    async start() {
+    async start(): Promise<void> {
         const streamFetcher = new StreamFetcher(this.brokerConfig.streamrUrl)
         this.addHttpServerRouter(dataProduceEndpoints(streamFetcher, this.publisher))
     }
 
-    async stop() {
+    async stop(): Promise<void> {
     }
 }

--- a/packages/broker/src/plugins/legacyWebsocket/Connection.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/Connection.ts
@@ -27,7 +27,7 @@ export class Connection extends EventEmitter {
     readonly messageLayerVersion: number
     private readonly socket: WebSocket
     private readonly duplexStream: stream.Duplex
-    private readonly streams: Stream[] = []
+    private readonly streams: Stream<Connection>[] = []
     private dead = false
     private highBackPressure = false
     private respondedPong = true
@@ -89,7 +89,7 @@ export class Connection extends EventEmitter {
         return this.socket.bufferedAmount
     }
 
-    getStreams(): Stream[] {
+    getStreams(): Stream<Connection>[] {
         return this.streams.slice() // return copy
     }
 
@@ -105,23 +105,23 @@ export class Connection extends EventEmitter {
         return this.respondedPong
     }
 
-    addStream(stream: Stream): void {
+    addStream(stream: Stream<Connection>): void {
         this.streams.push(stream)
     }
 
     removeStream(streamId: string, streamPartition: number): void {
-        const i = this.streams.findIndex((s: Stream) => s.id === streamId && s.partition === streamPartition)
+        const i = this.streams.findIndex((s: Stream<Connection>) => s.id === streamId && s.partition === streamPartition)
         if (i !== -1) {
             this.streams.splice(i, 1)
         }
     }
 
-    forEachStream(cb: (stream: Stream) => void): void {
+    forEachStream(cb: (stream: Stream<Connection>) => void): void {
         this.getStreams().forEach(cb)
     }
 
     getStreamsAsString(): string[] {
-        return this.streams.map((s: Stream) => s.toString())
+        return this.streams.map((s: Stream<Connection>) => s.toString())
     }
 
     ping(): void {

--- a/packages/broker/src/plugins/legacyWebsocket/RequestHandler.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/RequestHandler.ts
@@ -27,7 +27,7 @@ export class RequestHandler {
 
     streamFetcher: StreamFetcher
     publisher: Publisher
-    streams: StreamStateManager
+    streams: StreamStateManager<Connection>
     subscriptionManager: SubscriptionManager
     metrics: Metrics
     storageNodeRegistry: StorageNodeRegistry
@@ -37,7 +37,7 @@ export class RequestHandler {
     constructor(   
         streamFetcher: StreamFetcher,
         publisher: Publisher,
-        streams: StreamStateManager,
+        streams: StreamStateManager<Connection>,
         subscriptionManager: SubscriptionManager,
         metrics: Metrics,
         storageNodeRegistry: StorageNodeRegistry,

--- a/packages/broker/src/plugins/legacyWebsocket/RequestHandler.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/RequestHandler.ts
@@ -288,7 +288,7 @@ export class RequestHandler {
         }
     }
 
-    async unsubscribe(connection: Connection, request: UnsubscribeRequest, noAck = false) {
+    async unsubscribe(connection: Connection, request: UnsubscribeRequest, noAck = false): Promise<void> {
         const stream = this.streams.get(request.streamId, request.streamPartition)
 
         if (stream) {
@@ -352,7 +352,7 @@ export class RequestHandler {
         }
     }
 
-    onConnectionClose(connectionId: string) {
+    onConnectionClose(connectionId: string): void {
         const ongoingResendResponses = this.ongoingResendResponses.get(connectionId)
         if (ongoingResendResponses.length > 0) {
             logger.info('Abort %s ongoing resends for connection %s', ongoingResendResponses.length, connectionId)
@@ -361,7 +361,7 @@ export class RequestHandler {
         }
     }
 
-    close() {
+    close(): void {
         this.streams.close()
     }
 }

--- a/packages/broker/src/plugins/legacyWebsocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/WebsocketPlugin.ts
@@ -8,6 +8,7 @@ import { once } from "events"
 import fs from "fs"
 import http from 'http'
 import https from "https"
+import { Schema } from 'ajv'
 
 const logger = new Logger(module)
 
@@ -60,7 +61,7 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
         return this.websocketServer!.close()
     }
 
-    getConfigSchema(): Record<string, unknown> {
+    getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
@@ -248,7 +248,7 @@ export class WebsocketServer extends EventEmitter {
         this.connections.delete(connection)
 
         // Unsubscribe from all streams
-        connection.forEachStream((stream: Stream<any>) => {
+        connection.forEachStream((stream: Stream<Connection>) => {
             // for cleanup, spoof an UnsubscribeRequest to ourselves on the removed connection
             this.requestHandler.unsubscribe(
                 connection,

--- a/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
@@ -105,7 +105,7 @@ export class WebsocketServer extends EventEmitter {
                 }
             })
 
-        const streams = new StreamStateManager()
+        const streams = new StreamStateManager<Connection>()
         this.requestHandler = new RequestHandler(
             streamFetcher,
             publisher,
@@ -248,7 +248,7 @@ export class WebsocketServer extends EventEmitter {
         this.connections.delete(connection)
 
         // Unsubscribe from all streams
-        connection.forEachStream((stream: Stream) => {
+        connection.forEachStream((stream: Stream<any>) => {
             // for cleanup, spoof an UnsubscribeRequest to ourselves on the removed connection
             this.requestHandler.unsubscribe(
                 connection,
@@ -289,7 +289,7 @@ export class WebsocketServer extends EventEmitter {
         })
     }
 
-    private broadcastMessage(streamMessage: Protocol.StreamMessage, streams: StreamStateManager) {
+    private broadcastMessage(streamMessage: Protocol.StreamMessage, streams: StreamStateManager<Connection>) {
         const streamId = streamMessage.getStreamId()
         const streamPartition = streamMessage.getStreamPartition()
         const stream = streams.get(streamId, streamPartition)

--- a/packages/broker/src/plugins/metrics/ConsoleAndPM2Metrics.ts
+++ b/packages/broker/src/plugins/metrics/ConsoleAndPM2Metrics.ts
@@ -79,7 +79,7 @@ export class ConsoleAndPM2Metrics {
         })
     }
 
-    start() {
+    start(): void {
         logger.info('starting legacy metrics reporting interval')
         const reportingIntervalInMs = this.reportingIntervalSeconds * 1000
         const reportFn = async () => {
@@ -93,7 +93,7 @@ export class ConsoleAndPM2Metrics {
         this.timeout = setTimeout(reportFn, reportingIntervalInMs)
     }
 
-    stop() {
+    stop(): void {
         clearTimeout(this.timeout!)
     }
 

--- a/packages/broker/src/plugins/metrics/VolumeEndpoint.ts
+++ b/packages/broker/src/plugins/metrics/VolumeEndpoint.ts
@@ -1,11 +1,11 @@
-import express, { Request, Response } from 'express'
+import express, { Request, Response, Router } from 'express'
 import { MetricsContext } from 'streamr-network'
 import { LEGACY_API_ROUTE_PREFIX } from '../../httpServer'
 
 /**
  * Endpoint for GETing volume metrics
  */
-export const router = (metricsContext: MetricsContext) => {
+export const router = (metricsContext: MetricsContext): Router => {
     if (!metricsContext) {
         throw new Error('metricsContext not given!')
     }

--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -42,7 +42,7 @@ export class MetricsPublisher {
         }
     }
 
-    async ensureStreamsCreated() {
+    async ensureStreamsCreated(): Promise<void> {
         await Promise.all(Object.keys(STREAM_ID_SUFFIXES).map((periodLengthAsString: string) => this.ensureStreamCreated(Number(periodLengthAsString))))
     }
 

--- a/packages/broker/src/plugins/metrics/node/NodeMetrics.ts
+++ b/packages/broker/src/plugins/metrics/node/NodeMetrics.ts
@@ -77,7 +77,7 @@ export class NodeMetrics {
         this.minuteAggregator = new Aggregator(PERIOD_LENGTHS.ONE_MINUTE, this.sampleFactory, createListener(this.hourAggregator))
     }
 
-    async start() {
+    async start(): Promise<void> {
         await this.publisher.ensureStreamsCreated()
         const existingSamples = await this.publisher.fetchExistingSamples()
         this.hourAggregator.addSamples(existingSamples.minutes)
@@ -87,7 +87,7 @@ export class NodeMetrics {
         }, PERIOD_LENGTHS.FIVE_SECONDS)
     }
 
-    async collectSample(now: number) {
+    async collectSample(now: number): Promise<void> {
         const sample = await this.sampleFactory.createPrimary({
             start: now - PERIOD_LENGTHS.FIVE_SECONDS,
             end: now
@@ -99,7 +99,7 @@ export class NodeMetrics {
         }
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         this.scheduler?.stop()
         await this.publisher.stop()
     }

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -3,6 +3,7 @@ import { getPayloadFormat } from '../../helpers/PayloadFormat'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { MqttServer } from './MqttServer'
 import { Bridge } from './Bridge'
+import { Schema } from 'ajv'
 
 export interface MqttPluginConfig {
     port: number
@@ -21,7 +22,7 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         }
     }
 
-    async start() {
+    async start(): Promise<void> {
         this.server = new MqttServer(this.pluginConfig.port, this.apiAuthenticator)
         const bridge = new Bridge(
             this.streamrClient!, 
@@ -33,11 +34,11 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         return this.server.start()
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         await this.server!.stop()
     }
 
-    getConfigSchema() {
+    getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/mqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/mqtt/MqttServer.ts
@@ -43,17 +43,17 @@ export class MqttServer {
         })
     }
 
-    setListener(listener: MqttServerListener) {
+    setListener(listener: MqttServerListener): void {
         this.listener = listener
     }
 
-    async start() {
+    async start(): Promise<void> {
         this.server = net.createServer(this.aedes.handle)
         await util.promisify((callback: any) => this.server!.listen(this.port, callback))()
         logger.info(`MQTT server listening on port ${this.port}`)
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         if (!this.aedes.closed) {
             const closeAedes = util.promisify((callback: any) => this.aedes.close(callback))()
             const closeServer = util.promisify((callback: any) => this.server!.close(callback))()
@@ -62,7 +62,7 @@ export class MqttServer {
         }
     }
 
-    publish(topic: string, payload: string) {
+    publish(topic: string, payload: string): void {
         const packet: aedes.PublishPacket = {
             topic,
             payload,

--- a/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
+++ b/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
@@ -10,10 +10,10 @@ export class PublishHttpPlugin extends Plugin<void> {
         }
     }
 
-    async start() {
+    async start(): Promise<void> {
         this.addHttpServerRouter(createEndpoint(this.streamrClient!))
     }
 
-    async stop() {
+    async stop(): Promise<void> {
     }
 }

--- a/packages/broker/src/plugins/storage/DataMetadataEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataMetadataEndpoints.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express'
+import express, { Request, Response, Router } from 'express'
 import { Storage } from './Storage'
 import { LEGACY_API_ROUTE_PREFIX } from '../../httpServer'
 
@@ -6,7 +6,7 @@ const parseIntIfExists = (x: string | undefined): number | undefined => {
     return x === undefined ? undefined : parseInt(x)
 }
 
-export const router = (cassandraStorage: Storage) => {
+export const router = (cassandraStorage: Storage): Router => {
     const router = express.Router()
     const handler = async (req: Request, res: Response) => {
         const streamId = req.params.id

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -1,7 +1,7 @@
 /**
  * Endpoints for RESTful data requests
  */
-import express, { Request, Response } from 'express'
+import express, { Request, Response, Router } from 'express'
 import { MetricsContext, Protocol } from 'streamr-network'
 import { Metrics } from 'streamr-network/dist/helpers/MetricsContext'
 import { Logger } from 'streamr-network'
@@ -105,7 +105,7 @@ const createEndpointRoute = (
     })
 }
 
-export const router = (storage: Storage, streamFetcher: Todo, metricsContext: MetricsContext) => {
+export const router = (storage: Storage, streamFetcher: Todo, metricsContext: MetricsContext): Router => {
     const router = express.Router()
     const metrics = metricsContext.create('broker/http')
         .addRecordedMetric('outBytes')

--- a/packages/broker/src/plugins/storage/DeleteExpiredCmd.ts
+++ b/packages/broker/src/plugins/storage/DeleteExpiredCmd.ts
@@ -2,14 +2,42 @@ import cassandra, { Client } from 'cassandra-driver'
 import fetch from 'node-fetch'
 import pLimit, { Limit } from 'p-limit'
 import { Logger } from 'streamr-network'
-import { Todo } from '../../types'
-import { Bucket } from './Bucket'
 
 const logger = new Logger(module)
 
-const totalSizeOfBuckets = (buckets: Bucket[]) => buckets.reduce((mem, { size }) => mem + size, 0) / (1024 * 1024)
+const totalSizeOfBuckets = (buckets: BucketInfo[]) => buckets.reduce((mem, { size }) => mem + size, 0) / (1024 * 1024)
 
-const totalNumOfRecords = (buckets: Bucket[]) => buckets.reduce((mem, { records }) => mem + records, 0)
+const totalNumOfRecords = (buckets: BucketInfo[]) => buckets.reduce((mem, { records }) => mem + records, 0)
+
+interface StreamPart {
+    streamId: string,
+    partition: number
+}
+
+interface StreamPartInfo extends StreamPart {
+    storageDays: number
+}
+
+interface BucketInfo {
+    bucketId: string
+    dateCreate: number,
+    streamId: string,
+    partition: number,
+    records: number,
+    size: number,
+    storageDays: number
+}
+
+interface Options {
+    streamrBaseUrl: string,
+    cassandraUsername: string,
+    cassandraPassword: string,
+    cassandraHosts: string[],
+    cassandraDatacenter: string,
+    cassandraKeyspace: string,
+    bucketLimit: number,
+    dryRun?: boolean
+}
 
 export class DeleteExpiredCmd {
 
@@ -28,7 +56,7 @@ export class DeleteExpiredCmd {
         cassandraKeyspace,
         bucketLimit,
         dryRun = true
-    }: Todo) {
+    }: Options) {
         this.streamrBaseUrl = streamrBaseUrl
         this.dryRun = dryRun
         this.bucketLimit = bucketLimit || 10000000
@@ -69,10 +97,7 @@ export class DeleteExpiredCmd {
         await this.cassandraClient.shutdown()
     }
 
-    async _getStreams(): Promise<{
-        streamId: string,
-        partition: number
-    }[]> {
+    async _getStreams(): Promise<StreamPart[]> {
         const query = 'SELECT DISTINCT stream_id, partition FROM bucket'
         const resultSet = await this.cassandraClient.execute(query, [], {
             fetchSize: 100000
@@ -83,8 +108,8 @@ export class DeleteExpiredCmd {
         }))
     }
 
-    async _fetchStreamsInfo(streams: Todo): Promise<Todo> {
-        const tasks = streams.filter(Boolean).map((stream: Todo) => {
+    async _fetchStreamsInfo(streams: StreamPart[]): Promise<(StreamPartInfo|void)[]> {
+        const tasks = streams.filter(Boolean).map((stream: StreamPart) => {
             return this.limit(async () => {
                 const url = `${this.streamrBaseUrl}/api/v1/streams/${encodeURIComponent(stream.streamId)}/validation`
                 return fetch(url).then((res) => res.json()).then((json) => {
@@ -100,12 +125,13 @@ export class DeleteExpiredCmd {
         return Promise.all(tasks)
     }
 
-    async _getPotentiallyExpiredBuckets(streamsInfo: Todo): Promise<Todo> {
-        const result: Todo[] = []
+    async _getPotentiallyExpiredBuckets(streamsInfo: (StreamPartInfo|void)[]): Promise<BucketInfo[]> {
+        const result: BucketInfo[] = []
 
         const query = 'SELECT * FROM bucket WHERE stream_id = ? AND partition = ? AND date_create <= ?'
 
-        const tasks = streamsInfo.filter(Boolean).map((stream: Todo) => {
+        // @ts-expect-error void filtering
+        const tasks = streamsInfo.filter(Boolean).map((stream: StreamPartInfo) => {
             const { streamId, partition, storageDays } = stream
             const timestampBefore = Date.now() - 1000 * 60 * 60 * 24 * storageDays
             const params = [streamId, partition, timestampBefore]
@@ -116,7 +142,7 @@ export class DeleteExpiredCmd {
                 }).catch((err) => logger.error(err))
 
                 if (resultSet) {
-                    resultSet.rows.forEach((row: Todo) => {
+                    resultSet.rows.forEach((row: cassandra.types.Row) => {
                         result.push({
                             bucketId: row.id,
                             dateCreate: row.date_create,
@@ -135,12 +161,12 @@ export class DeleteExpiredCmd {
         return result
     }
 
-    async _filterExpiredBuckets(potentialBuckets: Todo): Promise<Todo> {
-        const result: Todo[] = []
+    async _filterExpiredBuckets(potentialBuckets: BucketInfo[]): Promise<BucketInfo[]> {
+        const result: BucketInfo[] = []
 
         const query = 'SELECT MAX(ts) AS m FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id = ?'
 
-        const tasks = potentialBuckets.filter(Boolean).map((bucket: Todo) => {
+        const tasks = potentialBuckets.filter(Boolean).map((bucket: BucketInfo) => {
             const { streamId, partition, bucketId, storageDays } = bucket
             const timestampBefore = Date.now() - 1000 * 60 * 60 * 24 * storageDays
             const params = [streamId, partition, bucketId]
@@ -163,7 +189,7 @@ export class DeleteExpiredCmd {
         return result
     }
 
-    async _deleteExpired(expiredBuckets: Todo[]): Promise<Todo> {
+    async _deleteExpired(expiredBuckets: BucketInfo[]): Promise<void[]> {
         const tasks = expiredBuckets.filter(Boolean).map((stream) => {
             const { bucketId, dateCreate, streamId, partition } = stream
             const queries = [

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -178,7 +178,7 @@ export class StorageConfig {
         return messageListener
     }
 
-    onAssignmentEvent(content: { storageNode: string, stream: { id: string, partitions: number }, event: string }) {
+    onAssignmentEvent(content: { storageNode: string, stream: { id: string, partitions: number }, event: string }): void {
         if (content.storageNode && typeof content.storageNode === 'string' && content.storageNode.toLowerCase() === this.clusterId.toLowerCase()) {
             logger.trace('Received storage assignment message: %o', content)
             const keys = new Set(
@@ -200,7 +200,7 @@ export class StorageConfig {
         }
     }
 
-    stopAssignmentEventListener(messageListener: (msg: StreamMessage<AssignmentMessage>) => void, streamrAddress: string, subscriptionManager: SubscriptionManager) {
+    stopAssignmentEventListener(messageListener: (msg: StreamMessage<AssignmentMessage>) => void, streamrAddress: string, subscriptionManager: SubscriptionManager): void {
         subscriptionManager.networkNode.removeMessageListener(messageListener)
         const assignmentStreamId = this.getAssignmentStreamId(streamrAddress)
         subscriptionManager.unsubscribe(assignmentStreamId, 0)

--- a/packages/broker/src/plugins/storage/StorageConfigEndpoints.ts
+++ b/packages/broker/src/plugins/storage/StorageConfigEndpoints.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express'
+import express, { Request, Response, Router } from 'express'
 import { StorageConfig } from './StorageConfig'
 import { LEGACY_API_ROUTE_PREFIX } from '../../httpServer'
 
@@ -22,7 +22,7 @@ const createHandler = (storageConfig: StorageConfig) => {
     }
 }
 
-export const router = (storageConfig: StorageConfig) => {
+export const router = (storageConfig: StorageConfig): Router => {
     const router = express.Router()
     const handler = createHandler(storageConfig)
     router.get(`${LEGACY_API_ROUTE_PREFIX}/streams/:id/storage/partitions/:partition`, handler)

--- a/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
+++ b/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
@@ -8,6 +8,7 @@ import { scheduleAtInterval } from '../../helpers/scheduler'
 import { withTimeout } from '../../helpers/withTimeout'
 import { fetchOrThrow } from '../../helpers/fetch'
 import { version as CURRENT_VERSION } from '../../../package.json'
+import { Schema } from 'ajv'
 
 const REWARD_STREAM_PARTITION = 0
 const LATENCY_POLL_INTERVAL = 30 * 60 * 1000
@@ -57,7 +58,7 @@ export class TestnetMinerPlugin extends Plugin<TestnetMinerPluginConfig> {
         this.streamId = this.pluginConfig.rewardStreamIds[Math.floor(Math.random()*this.pluginConfig.rewardStreamIds.length)]
     }
 
-    async start() {
+    async start(): Promise<void> {
         this.latencyPoller = await scheduleAtInterval(async () => {
             this.latestLatency = await this.getLatency()
         }, LATENCY_POLL_INTERVAL, true)
@@ -168,7 +169,7 @@ export class TestnetMinerPlugin extends Plugin<TestnetMinerPluginConfig> {
         }
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         this.latencyPoller?.stop()
         if (this.rewardSubscriptionRetryRef) {
             clearTimeout(this.rewardSubscriptionRetryRef)
@@ -176,7 +177,7 @@ export class TestnetMinerPlugin extends Plugin<TestnetMinerPluginConfig> {
         }
     }
 
-    getConfigSchema() {
+    getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -27,7 +27,7 @@ export class PublishConnection implements Connection {
         }
     }
 
-    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) {
+    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
         ws.on('message', (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)

--- a/packages/broker/src/plugins/websocket/SubscribeConnection.ts
+++ b/packages/broker/src/plugins/websocket/SubscribeConnection.ts
@@ -15,7 +15,7 @@ export class SubscribeConnection implements Connection {
         this.partitions = parseQueryParameterArray('partitions', queryParams, parsePositiveInteger)
     }
 
-    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) {
+    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
         const streamPartDefitions = (this.partitions !== undefined)
             ? this.partitions.map((streamPartition: number) => ({ streamId: this.streamId, streamPartition }))
             : [{ streamId: this.streamId }]

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -3,6 +3,7 @@ import { SslCertificateConfig } from '../../types'
 import { getPayloadFormat } from '../../helpers/PayloadFormat'
 import { WebsocketServer } from './WebsocketServer'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
+import { Schema } from 'ajv'
 
 export interface WebsocketPluginConfig {
     port: number
@@ -21,7 +22,7 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
         }
     }
 
-    async start() {
+    async start(): Promise<void> {
         this.server = new WebsocketServer(this.streamrClient!)
         await this.server.start(
             this.pluginConfig.port, 
@@ -31,11 +32,11 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
         )
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         await this.server!.stop()
     }
 
-    getConfigSchema() {
+    getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -44,7 +44,7 @@ export const createMessagingPluginTest = <T>(
     ports: Ports, 
     testModule: NodeJS.Module,
     pluginConfig: any = {}
-) => {
+): any => {
 
     describe(`Plugin: ${pluginName}`, () => {
 

--- a/packages/broker/test/integration/plugins/storage/MockStorageConfig.ts
+++ b/packages/broker/test/integration/plugins/storage/MockStorageConfig.ts
@@ -1,6 +1,6 @@
 import { StreamPart } from '../../../../src/types'
 
-export const createMockStorageConfig = (streams: StreamPart[]) => {
+export const createMockStorageConfig = (streams: StreamPart[]): any => {
     return {
         hasStream: (stream: StreamPart) => {
             return streams.some((s) => (s.id === stream.id) && (s.partition === stream.partition))

--- a/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
@@ -24,7 +24,7 @@ class MockClaimServer {
     pingEndpointCalled = false
     claimRequestBody: any
 
-    async start() {
+    async start(): Promise<Server> {
         const app = express()
         app.use(express.json())
         app.post('/claim', (req: Request, res: Response) => {
@@ -42,7 +42,7 @@ class MockClaimServer {
         return this.server
     }
 
-    async stop() {
+    async stop(): Promise<void> {
         this.server!.close()
         await once(this.server!, 'close')
     }

--- a/packages/broker/test/unit/plugins/legacyWebsocket/Connection.test.ts
+++ b/packages/broker/test/unit/plugins/legacyWebsocket/Connection.test.ts
@@ -71,8 +71,8 @@ describe('Connection', () => {
     describe('stream management', () => {
         describe('addStream', () => {
             it('adds stream to the connection', () => {
-                const stream1 = new Stream('stream', 0, '')
-                const stream2 = new Stream('stream', 1, '')
+                const stream1 = new Stream<any>('stream', 0, '')
+                const stream2 = new Stream<any>('stream', 1, '')
                 connection.addStream(stream1)
                 connection.addStream(stream2)
                 expect(connection.getStreams()).toEqual([stream1, stream2])
@@ -80,9 +80,9 @@ describe('Connection', () => {
         })
 
         describe('removeStream', () => {
-            let stream1: Stream
-            let stream2: Stream
-            let stream3: Stream
+            let stream1: Stream<any>
+            let stream2: Stream<any>
+            let stream3: Stream<any>
 
             beforeEach(() => {
                 stream1 = new Stream('stream1', 0, '')
@@ -130,9 +130,9 @@ describe('Connection', () => {
 
         describe('forEachStream', () => {
             it('iterates over each stream', () => {
-                const stream1 = new Stream('stream1', 0, '')
-                const stream2 = new Stream('stream2', 0, '')
-                const stream3 = new Stream('stream3', 0, '')
+                const stream1 = new Stream<any>('stream1', 0, '')
+                const stream2 = new Stream<any>('stream2', 0, '')
+                const stream3 = new Stream<any>('stream3', 0, '')
                 connection.addStream(stream1)
                 connection.addStream(stream2)
                 connection.addStream(stream3)

--- a/packages/broker/test/unit/plugins/legacyWebsocket/Stream.test.ts
+++ b/packages/broker/test/unit/plugins/legacyWebsocket/Stream.test.ts
@@ -4,7 +4,7 @@ import { Stream } from '../../../../src/Stream'
 describe('Stream', () => {
     it('addConnection adds connections', () => {
         // @ts-expect-error
-        const stream = new Stream('id', 0)
+        const stream = new Stream<string>('id', 0)
         stream.addConnection('a')
         stream.addConnection('b')
         stream.addConnection('c')
@@ -12,7 +12,7 @@ describe('Stream', () => {
     })
 
     describe('removeConnection', () => {
-        let stream: Stream
+        let stream: Stream<string>
 
         beforeEach(() => {
             // @ts-expect-error

--- a/packages/broker/test/unit/plugins/legacyWebsocket/StreamStateManager.test.ts
+++ b/packages/broker/test/unit/plugins/legacyWebsocket/StreamStateManager.test.ts
@@ -5,10 +5,10 @@ import { Stream } from '../../../../src/Stream'
 jest.useFakeTimers()
 
 describe('StreamStateManager', () => {
-    let streams: StreamStateManager
+    let streams: StreamStateManager<any>
 
     beforeEach(() => {
-        streams = new StreamStateManager()
+        streams = new StreamStateManager<any>()
     })
 
     afterEach(() => {
@@ -30,7 +30,7 @@ describe('StreamStateManager', () => {
     })
 
     describe('get', () => {
-        let stream: Stream
+        let stream: Stream<any>
         beforeEach(() => {
             stream = streams.create('streamId', 4)
         })
@@ -70,7 +70,7 @@ describe('StreamStateManager', () => {
     })
 
     describe('timeout behavior', () => {
-        let stream: Stream
+        let stream: Stream<any>
 
         beforeEach(() => {
             stream = streams.create('streamId', 0)

--- a/packages/broker/test/unit/plugins/storage/StorageConfigEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfigEndpoints.test.ts
@@ -16,21 +16,18 @@ describe('StorageConfigEndpoints', () => {
 
     it('stream in storage config', async () => {
         const app = express()
-        // @ts-expect-error
         app.use(router(storageConfig))
         await createRequest('existing', 123, app).expect(200)
     })
 
     it('stream not in storage config', async () => {
         const app = express()
-        // @ts-expect-error
         app.use(router(storageConfig))
         await createRequest('non-existing', 456, app).expect(404)
     })
 
     it('invalid partition', async () => {
         const app = express()
-        // @ts-expect-error
         app.use(router(storageConfig))
         await createRequest('foo', 'bar' as any, app).expect(400, 'Partition is not a number: bar')
     })


### PR DESCRIPTION
Now all functions have return types.  Removed eslint exception `"@typescript-eslint/explicit-module-boundary-types": "warn"` so that eslint will show an error if we miss a return type in the future.

Changed Todo types to actual types in `Stream`, `StreamStateManager` and `DeleteExpiredCmd`. `Stream` and `StreamStateManager` are now generic classes (the connection type is a generic type).