### PR TITLE
protocol: function return types

### DIFF
--- a/packages/protocol/src/protocol/control_layer/ControlMessage.ts
+++ b/packages/protocol/src/protocol/control_layer/ControlMessage.ts
@@ -55,7 +55,7 @@ export default class ControlMessage {
         this.requestId = requestId
     }
 
-    static registerSerializer(version: number, type: ControlMessageType, serializer: Serializer<ControlMessage>) {
+    static registerSerializer(version: number, type: ControlMessageType, serializer: Serializer<ControlMessage>): void {
         // Check the serializer interface
         if (!serializer.fromArray) {
             throw new Error(`Serializer ${JSON.stringify(serializer)} doesn't implement a method fromArray!`)
@@ -75,11 +75,11 @@ export default class ControlMessage {
         serializerByVersionAndType[version][type] = serializer
     }
 
-    static unregisterSerializer(version: number, type: ControlMessageType) {
+    static unregisterSerializer(version: number, type: ControlMessageType): void {
         delete serializerByVersionAndType[version][type]
     }
 
-    static getSerializer(version: number, type: ControlMessageType) {
+    static getSerializer(version: number, type: ControlMessageType): Serializer<ControlMessage> {
         const serializersByType = serializerByVersionAndType[version]
         if (!serializersByType) {
             throw new UnsupportedVersionError(version, `Supported versions: [${ControlMessage.getSupportedVersions()}]`)
@@ -91,18 +91,19 @@ export default class ControlMessage {
         return clazz
     }
 
-    static getSupportedVersions() {
+    static getSupportedVersions(): number[] {
         return Object.keys(serializerByVersionAndType).map((key) => parseInt(key, 10))
     }
 
-    serialize(version = this.version, ...typeSpecificSerializeArgs: any[]) {
+    serialize(version = this.version, ...typeSpecificSerializeArgs: any[]): string {
         return JSON.stringify(ControlMessage.getSerializer(version, this.type).toArray(this, ...typeSpecificSerializeArgs))
     }
 
     /**
      * Takes a serialized representation (array or string) of a message, and returns a ControlMessage instance.
      */
-    static deserialize(msg: any, ...typeSpecificDeserializeArgs: any[]) {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    static deserialize(msg: any, ...typeSpecificDeserializeArgs: any[]): ControlMessage {
         const messageArray = (typeof msg === 'string' ? JSON.parse(msg) : msg)
 
         /* eslint-disable prefer-destructuring */

--- a/packages/protocol/src/protocol/control_layer/broadcast_message/BroadcastMessageSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/broadcast_message/BroadcastMessageSerializerV1.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class BroadcastMessageSerializerV1 extends Serializer<BroadcastMessage> {
-    toArray(broadcastMessage: BroadcastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(broadcastMessage: BroadcastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.BroadcastMessage,
@@ -16,7 +16,7 @@ export default class BroadcastMessageSerializerV1 extends Serializer<BroadcastMe
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): BroadcastMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/broadcast_message/BroadcastMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/broadcast_message/BroadcastMessageSerializerV2.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class BroadcastMessageSerializerV2 extends Serializer<BroadcastMessage> {
-    toArray(broadcastMessage: BroadcastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(broadcastMessage: BroadcastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.BroadcastMessage,
@@ -17,7 +17,7 @@ export default class BroadcastMessageSerializerV2 extends Serializer<BroadcastMe
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): BroadcastMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/error_response/ErrorResponseSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/error_response/ErrorResponseSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ErrorResponseSerializerV1 extends Serializer<ErrorResponse> {
-    toArray(errorResponse: ErrorResponse) {
+    toArray(errorResponse: ErrorResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ErrorResponse,
@@ -15,7 +15,7 @@ export default class ErrorResponseSerializerV1 extends Serializer<ErrorResponse>
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ErrorResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/error_response/ErrorResponseSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/error_response/ErrorResponseSerializerV2.ts
@@ -6,7 +6,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ErrorResponseSerializerV2 extends Serializer<ErrorResponse> {
-    toArray(errorResponse: ErrorResponse) {
+    toArray(errorResponse: ErrorResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ErrorResponse,
@@ -16,7 +16,7 @@ export default class ErrorResponseSerializerV2 extends Serializer<ErrorResponse>
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ErrorResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/publish_request/PublishRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/publish_request/PublishRequestSerializerV1.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class PublishRequestSerializerV1 extends Serializer<PublishRequest> {
-    toArray(publishRequest: PublishRequest, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(publishRequest: PublishRequest, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.PublishRequest,
@@ -17,7 +17,7 @@ export default class PublishRequestSerializerV1 extends Serializer<PublishReques
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): PublishRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/publish_request/PublishRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/publish_request/PublishRequestSerializerV2.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class PublishRequestSerializerV2 extends Serializer<PublishRequest> {
-    toArray(publishRequest: PublishRequest, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(publishRequest: PublishRequest, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.PublishRequest,
@@ -18,7 +18,7 @@ export default class PublishRequestSerializerV2 extends Serializer<PublishReques
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): PublishRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendFromRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendFromRequestSerializerV1.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendFromRequestSerializerV1 extends Serializer<ResendFromRequest> {
-    toArray(resendFromRequest: ResendFromRequest) {
+    toArray(resendFromRequest: ResendFromRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendFromRequest,
@@ -22,7 +22,7 @@ export default class ResendFromRequestSerializerV1 extends Serializer<ResendFrom
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendFromRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendFromRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendFromRequestSerializerV2.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendFromRequestSerializerV2 extends Serializer<ResendFromRequest> {
-    toArray(resendFromRequest: ResendFromRequest) {
+    toArray(resendFromRequest: ResendFromRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendFromRequest,
@@ -21,7 +21,7 @@ export default class ResendFromRequestSerializerV2 extends Serializer<ResendFrom
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendFromRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendLastRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendLastRequestSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendLastRequestSerializerV1 extends Serializer<ResendLastRequest> {
-    toArray(resendLastRequest: ResendLastRequest) {
+    toArray(resendLastRequest: ResendLastRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendLastRequest,
@@ -19,7 +19,7 @@ export default class ResendLastRequestSerializerV1 extends Serializer<ResendLast
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendLastRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendLastRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendLastRequestSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendLastRequestSerializerV2 extends Serializer<ResendLastRequest> {
-    toArray(resendLastRequest: ResendLastRequest) {
+    toArray(resendLastRequest: ResendLastRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendLastRequest,
@@ -19,7 +19,7 @@ export default class ResendLastRequestSerializerV2 extends Serializer<ResendLast
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendLastRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendRangeRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendRangeRequestSerializerV1.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendRangeRequestSerializerV1 extends Serializer<ResendRangeRequest> {
-    toArray(resendRangeRequest: ResendRangeRequest) {
+    toArray(resendRangeRequest: ResendRangeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendRangeRequest,
@@ -23,7 +23,7 @@ export default class ResendRangeRequestSerializerV1 extends Serializer<ResendRan
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendRangeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_request/ResendRangeRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_request/ResendRangeRequestSerializerV2.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendRangeRequestSerializerV2 extends Serializer<ResendRangeRequest> {
-    toArray(resendRangeRequest: ResendRangeRequest) {
+    toArray(resendRangeRequest: ResendRangeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendRangeRequest,
@@ -23,7 +23,7 @@ export default class ResendRangeRequestSerializerV2 extends Serializer<ResendRan
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendRangeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseNoResendSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseNoResendSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendResponseNoResendSerializerV1 extends Serializer<ResendResponseNoResend> {
-    toArray(resendResponseNoResend: ResendResponseNoResend) {
+    toArray(resendResponseNoResend: ResendResponseNoResend): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseNoResend,
@@ -17,7 +17,7 @@ export default class ResendResponseNoResendSerializerV1 extends Serializer<Resen
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseNoResend {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseNoResendSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseNoResendSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendResponseNoResendSerializerV2 extends Serializer<ResendResponseNoResend> {
-    toArray(resendResponseNoResend: ResendResponseNoResend) {
+    toArray(resendResponseNoResend: ResendResponseNoResend): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseNoResend,
@@ -17,7 +17,7 @@ export default class ResendResponseNoResendSerializerV2 extends Serializer<Resen
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseNoResend {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResendingSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResendingSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendResponseResendingSerializerV1 extends Serializer<ResendResponseResending> {
-    toArray(resendResponseResending: ResendResponseResending) {
+    toArray(resendResponseResending: ResendResponseResending): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseResending,
@@ -17,7 +17,7 @@ export default class ResendResponseResendingSerializerV1 extends Serializer<Rese
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseResending {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResendingSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResendingSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendResponseResendingSerializerV2 extends Serializer<ResendResponseResending> {
-    toArray(resendResponseResending: ResendResponseResending) {
+    toArray(resendResponseResending: ResendResponseResending): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseResending,
@@ -17,7 +17,7 @@ export default class ResendResponseResendingSerializerV2 extends Serializer<Rese
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseResending {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResentSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResentSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class ResendResponseResentSerializerV1 extends Serializer<ResendResponseResent> {
-    toArray(resendResponseResent: ResendResponseResent) {
+    toArray(resendResponseResent: ResendResponseResent): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseResent,
@@ -17,7 +17,7 @@ export default class ResendResponseResentSerializerV1 extends Serializer<ResendR
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseResent {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResentSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/resend_response/ResendResponseResentSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ResendResponseResentSerializerV2 extends Serializer<ResendResponseResent> {
-    toArray(resendResponseResent: ResendResponseResent) {
+    toArray(resendResponseResent: ResendResponseResent): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.ResendResponseResent,
@@ -17,7 +17,7 @@ export default class ResendResponseResentSerializerV2 extends Serializer<ResendR
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ResendResponseResent {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/subscribe_request/SubscribeRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/subscribe_request/SubscribeRequestSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class SubscribeRequestSerializerV1 extends Serializer<SubscribeRequest> {
-    toArray(subscribeRequest: SubscribeRequest) {
+    toArray(subscribeRequest: SubscribeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.SubscribeRequest,
@@ -17,7 +17,7 @@ export default class SubscribeRequestSerializerV1 extends Serializer<SubscribeRe
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): SubscribeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/subscribe_request/SubscribeRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/subscribe_request/SubscribeRequestSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class SubscribeRequestSerializerV2 extends Serializer<SubscribeRequest> {
-    toArray(subscribeRequest: SubscribeRequest) {
+    toArray(subscribeRequest: SubscribeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.SubscribeRequest,
@@ -18,7 +18,7 @@ export default class SubscribeRequestSerializerV2 extends Serializer<SubscribeRe
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): SubscribeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/subscribe_response/SubscribeResponseSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/subscribe_response/SubscribeResponseSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class SubscribeResponseSerializerV1 extends Serializer<SubscribeResponse> {
-    toArray(subscribeResponse: SubscribeResponse) {
+    toArray(subscribeResponse: SubscribeResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.SubscribeResponse,
@@ -16,7 +16,7 @@ export default class SubscribeResponseSerializerV1 extends Serializer<SubscribeR
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): SubscribeResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/subscribe_response/SubscribeResponseSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/subscribe_response/SubscribeResponseSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class SubscribeResponseSerializerV2 extends Serializer<SubscribeResponse> {
-    toArray(subscribeResponse: SubscribeResponse) {
+    toArray(subscribeResponse: SubscribeResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.SubscribeResponse,
@@ -17,7 +17,7 @@ export default class SubscribeResponseSerializerV2 extends Serializer<SubscribeR
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): SubscribeResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unicast_message/UnicastMessageSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/unicast_message/UnicastMessageSerializerV1.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class UnicastMessageSerializerV1 extends Serializer<UnicastMessage> {
-    toArray(unicastMessage: UnicastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(unicastMessage: UnicastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnicastMessage,
@@ -17,7 +17,7 @@ export default class UnicastMessageSerializerV1 extends Serializer<UnicastMessag
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnicastMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unicast_message/UnicastMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/unicast_message/UnicastMessageSerializerV2.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class UnicastMessageSerializerV2 extends Serializer<UnicastMessage> {
-    toArray(unicastMessage: UnicastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION) {
+    toArray(unicastMessage: UnicastMessage, streamMessageVersion = StreamMessage.LATEST_VERSION): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnicastMessage,
@@ -17,7 +17,7 @@ export default class UnicastMessageSerializerV2 extends Serializer<UnicastMessag
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnicastMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequestSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequestSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class UnsubscribeRequestSerializerV1 extends Serializer<UnsubscribeRequest> {
-    toArray(unsubscribeRequest: UnsubscribeRequest) {
+    toArray(unsubscribeRequest: UnsubscribeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnsubscribeRequest,
@@ -16,7 +16,7 @@ export default class UnsubscribeRequestSerializerV1 extends Serializer<Unsubscri
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnsubscribeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequestSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequestSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class UnsubscribeRequestSerializerV2 extends Serializer<UnsubscribeRequest> {
-    toArray(unsubscribeRequest: UnsubscribeRequest) {
+    toArray(unsubscribeRequest: UnsubscribeRequest): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnsubscribeRequest,
@@ -17,7 +17,7 @@ export default class UnsubscribeRequestSerializerV2 extends Serializer<Unsubscri
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnsubscribeRequest {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseSerializerV1.ts
+++ b/packages/protocol/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseSerializerV1.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 1
 
 export default class UnsubscribeResponseSerializerV1 extends Serializer<UnsubscribeResponse> {
-    toArray(unsubscribeResponse: UnsubscribeResponse) {
+    toArray(unsubscribeResponse: UnsubscribeResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnsubscribeResponse,
@@ -16,7 +16,7 @@ export default class UnsubscribeResponseSerializerV1 extends Serializer<Unsubscr
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnsubscribeResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseSerializerV2.ts
+++ b/packages/protocol/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class UnsubscribeResponseSerializerV2 extends Serializer<UnsubscribeResponse> {
-    toArray(unsubscribeResponse: UnsubscribeResponse) {
+    toArray(unsubscribeResponse: UnsubscribeResponse): any[] {
         return [
             VERSION,
             ControlMessage.TYPES.UnsubscribeResponse,
@@ -17,7 +17,7 @@ export default class UnsubscribeResponseSerializerV2 extends Serializer<Unsubscr
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): UnsubscribeResponse {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/message_layer/MessageRef.ts
+++ b/packages/protocol/src/protocol/message_layer/MessageRef.ts
@@ -12,7 +12,7 @@ export default class MessageRef {
         this.sequenceNumber = sequenceNumber
     }
 
-    compareTo(other: MessageRef) {
+    compareTo(other: MessageRef): number {
         if (this.timestamp < other.timestamp) {
             return -1
         }
@@ -28,14 +28,14 @@ export default class MessageRef {
         return 0
     }
 
-    toArray() {
+    toArray(): any[] {
         return [
             this.timestamp,
             this.sequenceNumber,
         ]
     }
 
-    static fromArray(arr: any[]) {
+    static fromArray(arr: any[]): MessageRef {
         const [
             timestamp,
             sequenceNumber,
@@ -43,7 +43,7 @@ export default class MessageRef {
         return new MessageRef(timestamp, sequenceNumber)
     }
 
-    serialize() {
+    serialize(): string {
         return JSON.stringify(this.toArray())
     }
 

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -51,6 +51,21 @@ export type StreamMessageOptions<T> = {
     signature?: string | null
 }
 
+export interface ObjectType<T> { 
+    streamId: string
+    streamPartition: number
+    timestamp: number
+    sequenceNumber: number
+    publisherId: string
+    msgChainId: string
+    messageType: StreamMessageType
+    contentType: ContentType
+    encryptionType: EncryptionType
+    groupKeyId: string|null
+    content: string|T
+    signatureType: SignatureType;
+    signature: string|null
+}
 /**
  * Any object that contains a toStreamMessage interface.
  * e.g. GroupKeyMessage
@@ -449,7 +464,7 @@ export default class StreamMessage<T = unknown> {
         return !!(content && typeof content === 'object' && 'toStreamMessage' in content && typeof content.toStreamMessage === 'function')
     }
 
-    toObject() {
+    toObject(): ObjectType<T> {
         return {
             streamId: this.getStreamId(),
             streamPartition: this.getStreamPartition(),

--- a/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV30.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV30.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../Serializer'
 const VERSION = 30
 
 export default class StreamMessageSerializerV30 extends Serializer<StreamMessage> {
-    toArray(streamMessage: StreamMessage) {
+    toArray(streamMessage: StreamMessage): any[] {
         return [
             VERSION,
             streamMessage.messageId.toArray(),
@@ -19,7 +19,7 @@ export default class StreamMessageSerializerV30 extends Serializer<StreamMessage
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): StreamMessage<any> {
         const [
             version, // eslint-disable-line @typescript-eslint/no-unused-vars
             messageIdArr,

--- a/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV31.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV31.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../Serializer'
 const VERSION = 31
 
 export default class StreamMessageSerializerV31 extends Serializer<StreamMessage> {
-    toArray(streamMessage: StreamMessage) {
+    toArray(streamMessage: StreamMessage): any[] {
         return [
             VERSION,
             streamMessage.messageId.toArray(),
@@ -20,7 +20,7 @@ export default class StreamMessageSerializerV31 extends Serializer<StreamMessage
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): StreamMessage<any> {
         const [
             version, // eslint-disable-line @typescript-eslint/no-unused-vars
             messageIdArr,

--- a/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV32.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessageSerializerV32.ts
@@ -8,7 +8,7 @@ import { Serializer } from '../../Serializer'
 const VERSION = 32
 
 export default class StreamMessageSerializerV32 extends Serializer<StreamMessage> {
-    toArray(streamMessage: StreamMessage) {
+    toArray(streamMessage: StreamMessage): any[] {
         return [
             VERSION,
             streamMessage.messageId.toArray(),
@@ -24,7 +24,7 @@ export default class StreamMessageSerializerV32 extends Serializer<StreamMessage
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): StreamMessage<any> {
         const [
             version, // eslint-disable-line @typescript-eslint/no-unused-vars
             messageIdArr,

--- a/packages/protocol/src/protocol/tracker_layer/TrackerMessage.ts
+++ b/packages/protocol/src/protocol/tracker_layer/TrackerMessage.ts
@@ -43,7 +43,7 @@ export default class TrackerMessage {
         this.requestId = requestId
     }
 
-    static registerSerializer(version: number, type: number, serializer: Serializer<TrackerMessage>) {
+    static registerSerializer(version: number, type: number, serializer: Serializer<TrackerMessage>): void {
         // Check the serializer interface
         if (!serializer.fromArray) {
             throw new Error(`Serializer ${JSON.stringify(serializer)} doesn't implement a method fromArray!`)
@@ -63,11 +63,11 @@ export default class TrackerMessage {
         serializerByVersionAndType[version][type] = serializer
     }
 
-    static unregisterSerializer(version: number, type: TrackerMessageType) {
+    static unregisterSerializer(version: number, type: TrackerMessageType): void {
         delete serializerByVersionAndType[version][type]
     }
 
-    static getSerializer(version: number, type: TrackerMessageType) {
+    static getSerializer(version: number, type: TrackerMessageType): Serializer<TrackerMessage> {
         const serializersByType = serializerByVersionAndType[version]
         if (!serializersByType) {
             throw new UnsupportedVersionError(version, `Supported versions: [${TrackerMessage.getSupportedVersions()}]`)
@@ -79,18 +79,18 @@ export default class TrackerMessage {
         return clazz
     }
 
-    static getSupportedVersions() {
+    static getSupportedVersions(): number[] {
         return Object.keys(serializerByVersionAndType).map((key) => parseInt(key, 10))
     }
 
-    serialize(version = this.version, ...typeSpecificSerializeArgs: any[]) {
+    serialize(version = this.version, ...typeSpecificSerializeArgs: any[]): string {
         return JSON.stringify(TrackerMessage.getSerializer(version, this.type).toArray(this, ...typeSpecificSerializeArgs))
     }
 
     /**
      * Takes a serialized representation (array or string) of a message, and returns a ControlMessage instance.
      */
-    static deserialize(msg: any[] | string, ...typeSpecificDeserializeArgs: any[]) {
+    static deserialize(msg: any[] | string, ...typeSpecificDeserializeArgs: any[]): TrackerMessage {
         const messageArray = (typeof msg === 'string' ? JSON.parse(msg) : msg)
 
         /* eslint-disable prefer-destructuring */

--- a/packages/protocol/src/protocol/tracker_layer/error_message/ErrorMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/error_message/ErrorMessageSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class ErrorMessageSerializerV2 extends Serializer<ErrorMessage> {
-    toArray(errorMessage: ErrorMessage) {
+    toArray(errorMessage: ErrorMessage): (string | number)[] {
         return [
             VERSION,
             TrackerMessage.TYPES.ErrorMessage,
@@ -17,7 +17,7 @@ export default class ErrorMessageSerializerV2 extends Serializer<ErrorMessage> {
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): ErrorMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/tracker_layer/instruction_message/InstructionMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/instruction_message/InstructionMessageSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class InstructionMessageSerializerV2 extends Serializer<InstructionMessage> {
-    toArray(instructionMessage: InstructionMessage) {
+    toArray(instructionMessage: InstructionMessage): any[] {
         return [
             VERSION,
             TrackerMessage.TYPES.InstructionMessage,
@@ -19,7 +19,7 @@ export default class InstructionMessageSerializerV2 extends Serializer<Instructi
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): InstructionMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/tracker_layer/relay_message/RelayMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/relay_message/RelayMessageSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class RelayMessageSerializerV2 extends Serializer<RelayMessage> {
-    toArray(relayMessage: RelayMessage) {
+    toArray(relayMessage: RelayMessage): any[] {
         return [
             VERSION,
             TrackerMessage.TYPES.RelayMessage,
@@ -19,7 +19,7 @@ export default class RelayMessageSerializerV2 extends Serializer<RelayMessage> {
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): RelayMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/protocol/tracker_layer/status_message/StatusMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/status_message/StatusMessageSerializerV2.ts
@@ -7,7 +7,7 @@ import { Serializer } from '../../../Serializer'
 const VERSION = 2
 
 export default class StatusMessageSerializerV2 extends Serializer<StatusMessage> {
-    toArray(statusMessage: StatusMessage) {
+    toArray(statusMessage: StatusMessage): any[] {
         return [
             VERSION,
             TrackerMessage.TYPES.StatusMessage,
@@ -16,7 +16,7 @@ export default class StatusMessageSerializerV2 extends Serializer<StatusMessage>
         ]
     }
 
-    fromArray(arr: any[]) {
+    fromArray(arr: any[]): StatusMessage {
         const [
             version,
             type, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/protocol/src/utils/HashUtil.ts
+++ b/packages/protocol/src/utils/HashUtil.ts
@@ -9,7 +9,7 @@ import crypto from 'crypto'
  * @param key Input string or number
  * @returns Array index between [0..lengthOfArray-1]
  */
-export const keyToArrayIndex = (lengthOfArray: number, key: string | number) => {
+export const keyToArrayIndex = (lengthOfArray: number, key: string | number): number => {
     if (!(Number.isSafeInteger(lengthOfArray) && lengthOfArray > 0)) {
         throw new Error(`lengthOfArray is not a safe positive integer! ${lengthOfArray}`)
     }

--- a/packages/protocol/src/utils/NodeUtil.ts
+++ b/packages/protocol/src/utils/NodeUtil.ts
@@ -3,7 +3,7 @@ import { entropyToMnemonic, wordlists } from 'bip39'
 /**
  * @param address - valid eth address with leading 0x
  */
-export const generateMnemonicFromAddress = (address: string) =>
+export const generateMnemonicFromAddress = (address: string): string =>
     entropyToMnemonic(address.slice(2), wordlists.english)
         .split(' ')
         .slice(0, 3)
@@ -13,7 +13,7 @@ export const generateMnemonicFromAddress = (address: string) =>
 /**
  * @param id - node id
  */
-export const parseAddressFromNodeId = (id: string) => {
+export const parseAddressFromNodeId = (id: string): string => {
     const hashPos = id.indexOf('#')
 
     if (hashPos < 0) {

--- a/packages/protocol/test/benchmarks/deserialize.test.ts
+++ b/packages/protocol/test/benchmarks/deserialize.test.ts
@@ -6,6 +6,7 @@ const { StreamMessage, MessageID, MessageRef } = MessageLayer
 
 const ITERATIONS = 1000000
 
+// eslint-disable-next-line max-len
 const publishRequest = ControlMessage.deserialize('[1,8,[31,["kxeE-gyxS8CkuWYlfBKMVg",0,1567671580680,0,"0x8a9b2ca74d8c1c095d34de3f3cdd7462a5c9c9f4b84d11270a0ad885958bb963",'
     + '"7kcxFuyOs4ozeAcVfzJF"],[1567671579675,0],27,0,"{\\"random\\": 0.8314497807870005}",0,null],'
     + '"kuC8Ilzt2NURdpKxuYN2JBLkPQBJ0vN7NGIx5ohA7ZJafyh29I07fZR57Jq4fUBo"]')
@@ -46,6 +47,7 @@ describe('deserialize', () => {
 
         run(() => {
             return new StreamMessage({
+                // eslint-disable-next-line max-len
                 messageId: new MessageID('kxeE-gyxS8CkuWYlfBKMVg', 0, 1567671580680, 0, '0x8a9b2ca74d8c1c095d34de3f3cdd7462a5c9c9f4b84d11270a0ad885958bb963', '7kcxFuyOs4ozeAcVfzJF'),
                 prevMsgRef: new MessageRef(1567671579675, 0),
                 content: '{"random": 0.8314497807870005}',

--- a/packages/protocol/test/benchmarks/validate.test.ts
+++ b/packages/protocol/test/benchmarks/validate.test.ts
@@ -9,6 +9,7 @@ import StreamMessage from '../../src/protocol/message_layer/StreamMessage'
 import StreamMessageValidator from '../../src/utils/StreamMessageValidator'
 import '../../src/protocol/message_layer/StreamMessageSerializerV31'
 
+// eslint-disable-next-line max-len
 const streamMessage = StreamMessage.deserialize('[31,["tagHE6nTQ9SJV2wPoCxBFw",0,1587141844396,0,"0xD12b87c9325eB36801d6114A0D5334AC2A8D25D8","k000EDTMtqOTLM8sirFj"],[1587141844312,0],27,0,"{\\"eventType\\":\\"trade\\",\\"eventTime\\":1587141844398,\\"symbol\\":\\"ETHBTC\\",\\"tradeId\\":172530352,\\"price\\":0.02415,\\"quantity\\":0.296,\\"buyerOrderId\\":687544144,\\"sellerOrderId\\":687544104,\\"time\\":1587141844396,\\"maker\\":false,\\"ignored\\":true}",2,"0x31453f26d0fedbf2101f6a1535c8c1dc1646de809fcde3a1068dfda9e5d2af42105efd40fe26840f1cb1d81a8872180e5ff0b0404234e179bcd413ec2bbb8aa01b"]')
 
 const mocks = {

--- a/packages/protocol/test/unit/protocol/control_layer/PublishRequestSerializerV2.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/PublishRequestSerializerV2.test.ts
@@ -14,6 +14,7 @@ const message = new PublishRequest({
     streamMessage,
     sessionToken: 'sessionToken',
 })
+// eslint-disable-next-line max-len
 const serializedMessage = JSON.stringify([VERSION, ControlMessage.TYPES.PublishRequest, 'requestId', JSON.parse(streamMessage.serialize(30)), 'sessionToken'])
 
 describe('PublishRequestSerializerV2', () => {

--- a/packages/protocol/test/unit/protocol/control_layer/ResendFromRequestSerializerV1.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/ResendFromRequestSerializerV1.test.ts
@@ -15,6 +15,7 @@ const message = new ResendFromRequest({
     publisherId: 'publisherId',
     sessionToken: 'sessionToken',
 })
+// eslint-disable-next-line max-len
 const serializedMessage = JSON.stringify([VERSION, ControlMessage.TYPES.ResendFromRequest, 'streamId', 0, 'requestId', [132846894, 0], 'publisherId', null, 'sessionToken'])
 
 describe('ResendFromRequestSerializerV1', () => {

--- a/packages/protocol/test/unit/protocol/control_layer/ResendFromRequestSerializerV2.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/ResendFromRequestSerializerV2.test.ts
@@ -15,6 +15,7 @@ const message = new ResendFromRequest({
     publisherId: 'publisherId',
     sessionToken: 'sessionToken',
 })
+// eslint-disable-next-line max-len
 const serializedMessage = JSON.stringify([VERSION, ControlMessage.TYPES.ResendFromRequest, 'requestId', 'streamId', 0, [132846894, 0], 'publisherId', 'sessionToken'])
 
 describe('ResendFromRequestSerializerV2', () => {

--- a/packages/protocol/test/unit/protocol/control_layer/ResendRangeRequestSerializerV1.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/ResendRangeRequestSerializerV1.test.ts
@@ -16,6 +16,7 @@ const message = new ResendRangeRequest({
     msgChainId: 'msgChainId',
     sessionToken: 'sessionToken',
 })
+// eslint-disable-next-line max-len
 const serializedMessage = JSON.stringify([VERSION, ControlMessage.TYPES.ResendRangeRequest, 'streamId', 0, 'requestId', [132846894, 0], [132847000, 0], 'publisherId', 'msgChainId', 'sessionToken'])
 
 describe('ResendRangeRequestSerializerV1', () => {

--- a/packages/protocol/test/unit/protocol/control_layer/ResendRangeRequestSerializerV2.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/ResendRangeRequestSerializerV2.test.ts
@@ -16,6 +16,7 @@ const message = new ResendRangeRequest({
     msgChainId: 'msgChainId',
     sessionToken: 'sessionToken',
 })
+// eslint-disable-next-line max-len
 const serializedMessage = JSON.stringify([VERSION, ControlMessage.TYPES.ResendRangeRequest, 'requestId', 'streamId', 0, [132846894, 0], [132847000, 0], 'publisherId', 'msgChainId', 'sessionToken'])
 
 describe('ResendRangeRequestSerializerV2', () => {

--- a/packages/protocol/test/unit/utils/CachingStreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/CachingStreamMessageValidator.test.ts
@@ -41,6 +41,7 @@ describe('CachingStreamMessageValidator', () => {
         verify = sinon.stub().resolves(true)
         cacheTimeoutMillis = 15 * 60 * 1000
 
+        // eslint-disable-next-line max-len
         msg = StreamMessage.deserialize('[31,["tagHE6nTQ9SJV2wPoCxBFw",0,1587141844396,0,"0xbce3217F2AC9c8a2D14A6303F87506c4FC124014","k000EDTMtqOTLM8sirFj"],[1587141844312,0],27,0,"{\\"eventType\\":\\"trade\\",\\"eventTime\\":1587141844398,\\"symbol\\":\\"ETHBTC\\",\\"tradeId\\":172530352,\\"price\\":0.02415,\\"quantity\\":0.296,\\"buyerOrderId\\":687544144,\\"sellerOrderId\\":687544104,\\"time\\":1587141844396,\\"maker\\":false,\\"ignored\\":true}",2,"0x91c47df28dc3014a49ef50313efa8e40015eeeccea0cf006ab2c7b05efbb0ddc7e10e430aaa7ea6dd0ca5e05761eaf0c14c8ca09b57c8d8626da7bb9ea2d50fa1b"]')
     })
 
@@ -77,6 +78,7 @@ describe('CachingStreamMessageValidator', () => {
     })
 
     it('only calls the expensive function once for each different stream', async () => {
+        // eslint-disable-next-line max-len
         const msg2 = StreamMessage.deserialize('[31,["streamId",0,1587141844396,0,"0xbce3217F2AC9c8a2D14A6303F87506c4FC124014","k000EDTMtqOTLM8sirFj"],[1587141844312,0],27,0,"{\\"foo\\":\\"bar\\"}",2,"some-signature"]')
         const validator = getValidator()
 
@@ -84,7 +86,9 @@ describe('CachingStreamMessageValidator', () => {
         await validator.validate(msg2)
 
         assert.strictEqual((isPublisher as any).callCount, 2, `Unexpected calls: ${(isPublisher as any).getCalls()}`)
+        // eslint-disable-next-line max-len
         assert((isPublisher as any).calledWith('0xbce3217F2AC9c8a2D14A6303F87506c4FC124014', 'streamId'), `Unexpected calls: ${(isPublisher as any).getCalls()}`)
+        // eslint-disable-next-line max-len
         assert((isPublisher as any).calledWith('0xbce3217F2AC9c8a2D14A6303F87506c4FC124014', 'tagHE6nTQ9SJV2wPoCxBFw'), `Unexpected calls: ${(isPublisher as any).getCalls()}`)
     })
 

--- a/packages/protocol/test/unit/utils/OrderedMsgChain.test.ts
+++ b/packages/protocol/test/unit/utils/OrderedMsgChain.test.ts
@@ -546,14 +546,19 @@ describe('OrderedMsgChain', () => {
     describe('maxGapRequests', () => {
         it('call the gap handler maxGapRequests times and then fails with GapFillFailedError', (done) => {
             let counter = 0
-            util = new OrderedMsgChain('publisherId', 'msgChainId', () => {}, (from: MessageRef, to: MessageRef, publisherId: string, msgChainId: string) => {
-                assert.strictEqual(from.timestamp, msg1.getMessageRef().timestamp)
-                assert.strictEqual(from.sequenceNumber, msg1.getMessageRef().sequenceNumber + 1)
-                assert.deepStrictEqual(to, msg3.prevMsgRef)
-                assert.strictEqual(publisherId, 'publisherId')
-                assert.strictEqual(msgChainId, 'msgChainId')
-                counter += 1
-            }, 100, 100)
+            util = new OrderedMsgChain(
+                'publisherId', 
+                'msgChainId', 
+                () => {}, 
+                (from: MessageRef, to: MessageRef, publisherId: string, msgChainId: string) => {
+                    assert.strictEqual(from.timestamp, msg1.getMessageRef().timestamp)
+                    assert.strictEqual(from.sequenceNumber, msg1.getMessageRef().sequenceNumber + 1)
+                    assert.deepStrictEqual(to, msg3.prevMsgRef)
+                    assert.strictEqual(publisherId, 'publisherId')
+                    assert.strictEqual(msgChainId, 'msgChainId')
+                    counter += 1
+                }, 
+                100, 100)
             util.once('error', (err: Error) => {
                 expect(err).toBeInstanceOf(GapFillFailedError)
                 if (err instanceof GapFillFailedError) {
@@ -696,7 +701,8 @@ describe('OrderedMsgChain', () => {
 
                 expect(received)
                 done(new Error('Was expecting to receive messages ordered per timestamp but instead received timestamps in this '
-                                + `order:\n${receivedTimestamps}.\nThe unordered messages were processed in the following timestamp order:\n${timestamps}`))
+                // eslint-disable-next-line max-len
+                    + `order:\n${receivedTimestamps}.\nThe unordered messages were processed in the following timestamp order:\n${timestamps}`))
                 return
             }
             done()

--- a/packages/protocol/test/unit/utils/OrderedMsgChain.test.ts
+++ b/packages/protocol/test/unit/utils/OrderedMsgChain.test.ts
@@ -701,7 +701,7 @@ describe('OrderedMsgChain', () => {
 
                 expect(received)
                 done(new Error('Was expecting to receive messages ordered per timestamp but instead received timestamps in this '
-                // eslint-disable-next-line max-len
+                    // eslint-disable-next-line max-len
                     + `order:\n${receivedTimestamps}.\nThe unordered messages were processed in the following timestamp order:\n${timestamps}`))
                 return
             }

--- a/packages/protocol/test/unit/utils/SigningUtil.test.ts
+++ b/packages/protocol/test/unit/utils/SigningUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import assert from 'assert'
 
 import SigningUtil from '../../../src/utils/SigningUtil'


### PR DESCRIPTION
Added missing return types. Also disabled/fixed `max-len` warnings in some test files.