### PR TITLE
Update node-datachannel to v0.1.11

### DIFF
--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -9524,9 +9524,9 @@
 			"dev": true
 		},
 		"node-datachannel": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.10.tgz",
-			"integrity": "sha512-q8iD3VUbY1xws5OFiPukS/G4twrekTmQNI/cRK0F3K5wwMffM2PUgkmL+/6DrPYTh7+QM35+evS8+k+83Z/yTQ==",
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.11.tgz",
+			"integrity": "sha512-ziTWePzHO4VnbRZ0iQNhNsUw1ge89iQj8xS1MKZgiTrnK0OT8vkfTsxOm+9tCOcZCYqjrBuGRNlYi/yfZugEpw==",
 			"requires": {
 				"prebuild-install": "^5.3.6"
 			},

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
     "morgan": "^1.10.0",
-    "node-datachannel": "^0.1.10",
+    "node-datachannel": "^0.1.11",
     "pino": "^6.11.3",
     "setimmediate": "^1.0.5",
     "streamr-client-protocol": "^9.1.0",


### PR DESCRIPTION
This PR updates node-datachannel to v0.1.11 with libdatachannel v0.15.3, introducing fixes for freezes seen on storage nodes:
- Updated usrsctp dependency with global locks replaced by RW locks instead of mutexes as a mitigation against deadlocks
- Fixed a bug where a thread of the thread pool would hang during Peer Connection destruction