### PR TITLE
ci(broker): rm extranous test-sequential run

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -85,7 +85,6 @@ jobs:
         with:
           services-to-start: "core-api cassandra nginx parity-sidechain-node0"
       - run: npm run test-integration
-      - run: npm run test-sequential
         env:
           CI: true
           LOG_LEVEL: warn


### PR DESCRIPTION
Turns out `npm run test-integration` already runs sequential tests, no need to run again.