### PR TITLE
network: refactor inbound/outboundNodes to neighbors

### DIFF
--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -52,8 +52,7 @@ export interface Location {
 
 export interface StreamStatus {
     streamKey: StreamKey
-    inboundNodes: NodeId[]
-    outboundNodes: NodeId[]
+    neighbors: NodeId[]
     counter: number // TODO this field could be a field of "Status" interface, not this interface?
 }
 

--- a/packages/network/src/logic/node/NetworkNode.ts
+++ b/packages/network/src/logic/node/NetworkNode.ts
@@ -38,7 +38,7 @@ export class NetworkNode extends Node {
     }
 
     getNeighborsForStream(streamId: string, streamPartition: number): ReadonlyArray<NodeId> {
-        return this.streams.getAllNodesForStream(new StreamIdAndPartition(streamId, streamPartition))
+        return this.streams.getNeighborsForStream(new StreamIdAndPartition(streamId, streamPartition))
     }
 
     getRtt(nodeId: NodeId): number|undefined {

--- a/packages/network/src/logic/node/Node.ts
+++ b/packages/network/src/logic/node/Node.ts
@@ -245,7 +245,7 @@ export class Node extends EventEmitter {
             streamMessage.getStreamId(),
             streamMessage.getStreamPartition()
         )
-        const subscribers = this.streams.getOutboundNodesForStream(streamIdAndPartition).filter((n) => n !== source)
+        const subscribers = this.streams.getNeighborsForStream(streamIdAndPartition).filter((n) => n !== source)
 
         if (!subscribers.length) {
             logger.debug('put back to buffer because could not propagate to %d nodes or more: %j',
@@ -318,8 +318,7 @@ export class Node extends EventEmitter {
     }
 
     private subscribeToStreamOnNode(node: NodeId, streamId: StreamIdAndPartition, sendStatus = true): NodeId {
-        this.streams.addInboundNode(streamId, node)
-        this.streams.addOutboundNode(streamId, node)
+        this.streams.addNeighbor(streamId, node)
         this.handleBufferedMessages(streamId)
         if (sendStatus) {
             this.trackerManager.sendStreamStatus(streamId)

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -3,6 +3,7 @@ import { DuplicateMessageDetector, NumberPair } from './DuplicateMessageDetector
 import { MessageLayer } from 'streamr-client-protocol'
 import { NodeId } from './Node'
 import { COUNTER_UNSUBSCRIBE } from '../tracker/InstructionCounter'
+import _ from 'lodash'
 
 interface StreamState {
     detectors: Map<string, DuplicateMessageDetector> // "publisherId-msgChainId" => DuplicateMessageDetector
@@ -136,7 +137,7 @@ export class StreamManager {
         this.streams.forEach(({ neighbors }) => {
             nodes.push(...neighbors)
         })
-        return [...new Set(nodes)]
+        return _.uniq(nodes)
     }
 
     hasNeighbor(streamId: StreamIdAndPartition, node: NodeId): boolean {

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -134,11 +134,6 @@ export class StreamManager {
         return [...this.streams.get(streamId.key())!.neighbors]
     }
 
-    // TODO callers could use getNeighborsForStream (if sorting is not needed)
-    getAllNodesForStream(streamId: StreamIdAndPartition): ReadonlyArray<NodeId> {
-        return [...this.getNeighborsForStream(streamId)].sort()
-    }
-
     getAllNodes(): ReadonlyArray<NodeId> {
         const nodes: NodeId[] = []
         this.streams.forEach(({ neighbors }) => {

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -96,12 +96,9 @@ export class StreamManager {
         return streams
     }
 
-    // TODO could this method return void as callers don't read the return value?
-    removeStream(streamId: StreamIdAndPartition): ReadonlyArray<NodeId> {
+    removeStream(streamId: StreamIdAndPartition): void {
         this.verifyThatIsSetUp(streamId)
-        const { neighbors } = this.streams.get(streamId.key())!
         this.streams.delete(streamId.key())
-        return [...new Set([...neighbors])]
     }
 
     isSetUp(streamId: StreamIdAndPartition): boolean {

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -177,7 +177,7 @@ export class TrackerManager {
         logger.trace('received instructions for %s, nodes to connect %o', streamId, nodeIds)
 
         this.subscriber.subscribeToStreamIfHaveNotYet(streamId, false)
-        const currentNodes = this.streamManager.getAllNodesForStream(streamId)
+        const currentNodes = this.streamManager.getNeighborsForStream(streamId)
         const nodesToUnsubscribeFrom = currentNodes.filter((nodeId) => !nodeIds.includes(nodeId))
 
         nodesToUnsubscribeFrom.forEach((nodeId) => {

--- a/packages/network/src/logic/tracker/OverlayTopology.ts
+++ b/packages/network/src/logic/tracker/OverlayTopology.ts
@@ -50,7 +50,7 @@ export class OverlayTopology {
     }
 
     update(nodeId: NodeId, neighbors: NodeId[]): void {
-        const newNeighbors = _.uniq([...neighbors])
+        const newNeighbors = _.uniq(neighbors)
             .filter((n) => n in this.nodes)
             .filter((n) => n !== nodeId) // in case nodeId is reporting itself as neighbor
 

--- a/packages/network/src/logic/tracker/OverlayTopology.ts
+++ b/packages/network/src/logic/tracker/OverlayTopology.ts
@@ -1,4 +1,5 @@
 import { NodeId } from '../node/Node'
+import _ from 'lodash'
 
 // From: https://gist.github.com/guilhermepontes/17ae0cc71fa2b13ea8c20c94c5c35dc4
 const shuffleArray = <T>(arr: Array<T>): Array<T> => arr
@@ -49,7 +50,7 @@ export class OverlayTopology {
     }
 
     update(nodeId: NodeId, neighbors: NodeId[]): void {
-        const newNeighbors = [...neighbors]
+        const newNeighbors = _.uniq([...neighbors])
             .filter((n) => n in this.nodes)
             .filter((n) => n !== nodeId) // in case nodeId is reporting itself as neighbor
 

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -14,8 +14,7 @@ const WAIT_TIME = 2000
 const formStatus = (counter1: number, nodes1: NodeId[]): Partial<Status> => ({
     stream: {
         streamKey: 'stream-1::0',
-        inboundNodes: nodes1,
-        outboundNodes: nodes1,
+        neighbors: nodes1,
         counter: counter1
     }
 })

--- a/packages/network/test/integration/tracker-node-reconnect-instructions.test.ts
+++ b/packages/network/test/integration/tracker-node-reconnect-instructions.test.ts
@@ -75,9 +75,9 @@ describe('Check tracker instructions to node', () => {
         const streamIdAndPartition = new StreamIdAndPartition(streamId, 0)
 
         // @ts-expect-error private field
-        expect(nodeOne.streams.getAllNodesForStream(streamIdAndPartition).length).toBe(1)
+        expect(nodeOne.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(1)
         // @ts-expect-error private field
-        expect(nodeTwo.streams.getAllNodesForStream(streamIdAndPartition).length).toBe(1)
+        expect(nodeTwo.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(1)
         
         // send empty list and wait for expected events
         await runAndWaitForEvents([
@@ -99,8 +99,8 @@ describe('Check tracker instructions to node', () => {
         ])
 
         // @ts-expect-error private field
-        expect(nodeOne.streams.getAllNodesForStream(streamIdAndPartition).length).toBe(0)
+        expect(nodeOne.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(0)
         // @ts-expect-error private field
-        expect(nodeTwo.streams.getAllNodesForStream(streamIdAndPartition).length).toBe(0)
+        expect(nodeTwo.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(0)
     })
 })

--- a/packages/network/test/integration/tracker-node-status.test.ts
+++ b/packages/network/test/integration/tracker-node-status.test.ts
@@ -7,7 +7,7 @@ import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { Event as NodeEvent } from '../../src/logic/node/Node'
 
 /**
- * This test verifies that tracker receives status messages from nodes with list of inBound and outBound connections
+ * This test verifies that tracker receives status messages from nodes with list of neighbor connections
  */
 
 // Seems to only be able to perform one connection on the tracker using the split ws client/server (???)

--- a/packages/network/test/unit/InstructionCounter.test.ts
+++ b/packages/network/test/unit/InstructionCounter.test.ts
@@ -12,8 +12,7 @@ describe('InstructionCounter', () => {
         const status: Partial<Status> = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 123
             }
         }
@@ -30,16 +29,14 @@ describe('InstructionCounter', () => {
         const status1 = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
                 streamKey: 'stream-2',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 3
             }
         }
@@ -56,16 +53,14 @@ describe('InstructionCounter', () => {
         const status1 = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 3
             }
         }
@@ -81,8 +76,7 @@ describe('InstructionCounter', () => {
         const status = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 0
             }
         }
@@ -97,8 +91,7 @@ describe('InstructionCounter', () => {
         const status = {
             stream: {
                 streamKey: 'stream-1',
-                inboundNodes: [],
-                outboundNodes: [],
+                neighbors: [],
                 counter: 0
             }
         }

--- a/packages/network/test/unit/StreamManager.test.ts
+++ b/packages/network/test/unit/StreamManager.test.ts
@@ -34,9 +34,9 @@ describe('StreamManager', () => {
         ])
         expect(manager.getStreamsAsKeys()).toEqual(['stream-1::0', 'stream-1::1', 'stream-2::0'])
 
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toEqual([])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toEqual([])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toEqual([])
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toBeEmpty()
     })
 
     test('cannot re-setup same stream', () => {
@@ -108,9 +108,8 @@ describe('StreamManager', () => {
         manager.addNeighbor(streamId2, 'node-2')
         manager.addNeighbor(streamId2, 'node-3')
 
-        expect(manager.getNeighborsForStream(streamId)).toEqual(['node-1', 'node-2'])
-        expect(manager.getAllNodesForStream(streamId)).toEqual(['node-1', 'node-2'])
-        expect(manager.getAllNodesForStream(streamId2)).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         expect(manager.hasNeighbor(streamId, 'node-1')).toEqual(true)
         expect(manager.hasNeighbor(streamId, 'node-2')).toEqual(true)
@@ -135,19 +134,19 @@ describe('StreamManager', () => {
         manager.addNeighbor(streamId2, 'node-2')
         manager.addNeighbor(streamId2, 'node-3')
 
-        expect(manager.getAllNodesForStream(streamId)).toEqual(['node-1', 'node-2'])
-        expect(manager.getAllNodesForStream(streamId2)).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         manager.removeNodeFromStream(streamId, 'node-1')
 
-        expect(manager.getAllNodesForStream(streamId)).toEqual(['node-2'])
-        expect(manager.getAllNodesForStream(streamId2)).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         manager.removeNodeFromStream(streamId2, 'node-3')
-        expect(manager.getAllNodesForStream(streamId)).toEqual(['node-2'])
-        expect(manager.getAllNodesForStream(streamId2)).toEqual(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2'])
 
-        expect(manager.getNeighborsForStream(streamId)).toEqual(['node-2'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
 
         expect(manager.hasNeighbor(streamId, 'node-1')).toEqual(false)
         expect(manager.isNodePresent('node-1')).toEqual(true)
@@ -172,9 +171,9 @@ describe('StreamManager', () => {
 
         manager.removeNodeFromAllStreams('node')
 
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toEqual(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toEqual(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toEqual(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toIncludeSameMembers(['should-not-be-removed'])
 
         expect(manager.hasNeighbor(new StreamIdAndPartition('stream-1', 0), 'node')).toEqual(false)
         expect(manager.hasNeighbor(new StreamIdAndPartition('stream-2', 0), 'node')).toEqual(false)


### PR DESCRIPTION
Simplify status message content and topology handling:
- Previously each status message contained `inboundNodes` and `outboundNodes` for a stream. 
- Those two arrays had exactly same content
- Now we use one array, called `neighbors`

There is also a backwards compatibility handling `Tracker.ts`, which enables the tracker to receive the statuses in the old format.