### PR TITLE
network: extract DisconnectionManager from Node

### DIFF
--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -27,6 +27,8 @@ export interface DisconnectionManagerOptions {
  *      from.
  */
 export class DisconnectionManager {
+    public static DISCONNECTION_REASON = 'no shared streams'
+
     private readonly disconnectionTimers = new Map<NodeId, NodeJS.Timeout>()
     private readonly getAllNodes: GetAllNodesFn
     private readonly hasSharedStreams: HasSharedStreamsFn
@@ -93,6 +95,6 @@ export class DisconnectionManager {
 
     private loggedDisconnect(nodeId: NodeId): void {
         logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
-        this.disconnect(nodeId, 'no shared streams')
+        this.disconnect(nodeId, DisconnectionManager.DISCONNECTION_REASON)
     }
 }

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -16,6 +16,16 @@ export interface DisconnectionManagerOptions {
     cleanUpIntervalInMs: number
 }
 
+/**
+ * DisconnectionManager assists a network node in disconnecting from other nodes when streams are
+ * no longer shared between them.
+ *
+ * There are two ways this is achieved:
+ *  1. Manual: a node can schedule (and cancel) disconnections that get executed after `disconnectionDelayInMs` if
+ *      they still don't share streams.
+ *  2. Automatic: a clean up interval is ran periodically in which any node without shared streams gets disconnected
+ *      from.
+ */
 export class DisconnectionManager {
     private readonly disconnectionTimers: Record<NodeId, NodeJS.Timeout> = Object.create(null)
     private readonly getAllNodes: GetAllNodesFn

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -4,14 +4,14 @@ import { Logger } from '../../helpers/Logger'
 
 type GetAllNodesFn = () => ReadonlyArray<NodeId>
 type HasSharedStreamsFn = (nodeId: NodeId) => boolean
-type DisconnectionFn = (nodeId: NodeId, reason: string) => void
+type DisconnectFn = (nodeId: NodeId, reason: string) => void
 
 const logger = new Logger(module)
 
 export interface DisconnectionManagerOptions {
     getAllNodes: GetAllNodesFn,
     hasSharedStreams: HasSharedStreamsFn,
-    disconnect: DisconnectionFn,
+    disconnect: DisconnectFn,
     disconnectionDelayInMs: number,
     cleanUpIntervalInMs: number
 }
@@ -20,7 +20,7 @@ export class DisconnectionManager {
     private readonly disconnectionTimers: Record<NodeId, NodeJS.Timeout> = Object.create(null)
     private readonly getAllNodes: GetAllNodesFn
     private readonly hasSharedStreams: HasSharedStreamsFn
-    private readonly disconnect: DisconnectionFn
+    private readonly disconnect: DisconnectFn
     private readonly disconnectionDelayInMs: number
     private readonly cleanUpIntervalInMs: number
     private connectionCleanUpInterval: NodeJS.Timeout | null = null

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -3,54 +3,83 @@ import { NameDirectory } from '../../NameDirectory'
 import { DisconnectionReason } from '../../connection/ws/AbstractWsEndpoint'
 import { Logger } from '../../helpers/Logger'
 
-type HasSharedStreamsFn = (neighborId: NodeId) => boolean
-type DisconnectionFn = (neighborId: NodeId, reason: DisconnectionReason) => void
+type GetAllNodesFn = () => ReadonlyArray<NodeId>
+type HasSharedStreamsFn = (nodeId: NodeId) => boolean
+type DisconnectionFn = (nodeId: NodeId, reason: DisconnectionReason) => void
 
 const logger = new Logger(module)
 
 export interface DisconnectionManagerOptions {
+    getAllNodes: GetAllNodesFn,
     hasSharedStreams: HasSharedStreamsFn,
     disconnect: DisconnectionFn,
-    disconnectionDelayInMs: number
+    disconnectionDelayInMs: number,
+    cleanUpIntervalInMs: number
 }
 
 export class DisconnectionManager {
     private readonly disconnectionTimers: Record<NodeId, NodeJS.Timeout> = Object.create(null)
+    private readonly getAllNodes: GetAllNodesFn
     private readonly hasSharedStreams: HasSharedStreamsFn
     private readonly disconnect: DisconnectionFn
     private readonly disconnectionDelayInMs: number
+    private readonly cleanUpIntervalInMs: number
+    private connectionCleanUpInterval: NodeJS.Timeout | null = null
 
-    constructor({ hasSharedStreams, disconnect, disconnectionDelayInMs }: DisconnectionManagerOptions) {
+    constructor({
+        getAllNodes,
+        hasSharedStreams,
+        disconnect,
+        disconnectionDelayInMs,
+        cleanUpIntervalInMs
+    }: DisconnectionManagerOptions) {
+        this.getAllNodes = getAllNodes
         this.hasSharedStreams = hasSharedStreams
         this.disconnect = disconnect
         this.disconnectionDelayInMs = disconnectionDelayInMs
+        this.cleanUpIntervalInMs = cleanUpIntervalInMs
     }
 
-    scheduleDisconnectionIfNoSharedStreams(neighborId: NodeId): void {
-        if (!this.hasSharedStreams(neighborId)) {
-            this.cancelScheduledDisconnection(neighborId)
-            this.disconnectionTimers[neighborId] = setTimeout(() => {
-                delete this.disconnectionTimers[neighborId]
-                if (!this.hasSharedStreams(neighborId)) {
-                    logger.debug('Executing scheduled disconnect from %s', NameDirectory.getName(neighborId))
-                    this.disconnect(neighborId, DisconnectionReason.NO_SHARED_STREAMS)
-                }
-            }, this.disconnectionDelayInMs)
-            logger.trace('Scheduled disconnection from %s in %d ms', neighborId, this.disconnectionDelayInMs)
-        }
-    }
-
-    cancelScheduledDisconnection(neighborId: NodeId): void {
-        if (this.disconnectionTimers[neighborId] != null) {
-            clearTimeout(this.disconnectionTimers[neighborId])
-            delete this.disconnectionTimers[neighborId]
-            logger.trace('Canceled scheduled disconnection from %s', neighborId)
-        }
+    start(): void {
+        this.connectionCleanUpInterval = setInterval(() => {
+            const nodeIds = this.getAllNodes()
+            const nonNeighborNodeIds = nodeIds.filter((nodeId) => !this.hasSharedStreams(nodeId))
+            if (nonNeighborNodeIds.length > 0) {
+                logger.debug('connectionCleanUpInterval: disconnecting from %d nodes', nonNeighborNodeIds.length)
+                nonNeighborNodeIds.forEach((nodeId) => {
+                    logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
+                    this.disconnect(nodeId, DisconnectionReason.NO_SHARED_STREAMS)
+                })
+            }
+        }, this.cleanUpIntervalInMs)
     }
 
     stop(): void {
+        clearInterval(this.connectionCleanUpInterval!)
         Object.values(this.disconnectionTimers).forEach((timeout) => {
             clearTimeout(timeout)
         })
+    }
+
+    scheduleDisconnectionIfNoSharedStreams(nodeId: NodeId): void {
+        if (!this.hasSharedStreams(nodeId)) {
+            this.cancelScheduledDisconnection(nodeId)
+            this.disconnectionTimers[nodeId] = setTimeout(() => {
+                delete this.disconnectionTimers[nodeId]
+                if (!this.hasSharedStreams(nodeId)) {
+                    logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
+                    this.disconnect(nodeId, DisconnectionReason.NO_SHARED_STREAMS)
+                }
+            }, this.disconnectionDelayInMs)
+            logger.trace('scheduled disconnection from %s in %d ms', nodeId, this.disconnectionDelayInMs)
+        }
+    }
+
+    cancelScheduledDisconnection(nodeId: NodeId): void {
+        if (this.disconnectionTimers[nodeId] != null) {
+            clearTimeout(this.disconnectionTimers[nodeId])
+            delete this.disconnectionTimers[nodeId]
+            logger.trace('canceled scheduled disconnection from %s', nodeId)
+        }
     }
 }

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -56,8 +56,7 @@ export class DisconnectionManager {
             if (nonNeighborNodeIds.length > 0) {
                 logger.debug('connectionCleanUpInterval: disconnecting from %d nodes', nonNeighborNodeIds.length)
                 nonNeighborNodeIds.forEach((nodeId) => {
-                    logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
-                    this.disconnect(nodeId, 'no shared streams')
+                    this.loggedDisconnect(nodeId)
                 })
             }
         }, this.cleanUpIntervalInMs)
@@ -76,8 +75,7 @@ export class DisconnectionManager {
             this.disconnectionTimers[nodeId] = setTimeout(() => {
                 delete this.disconnectionTimers[nodeId]
                 if (!this.hasSharedStreams(nodeId)) {
-                    logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
-                    this.disconnect(nodeId, 'no shared streams')
+                    this.loggedDisconnect(nodeId)
                 }
             }, this.disconnectionDelayInMs)
             logger.trace('scheduled disconnection from %s in %d ms', nodeId, this.disconnectionDelayInMs)
@@ -90,5 +88,10 @@ export class DisconnectionManager {
             delete this.disconnectionTimers[nodeId]
             logger.trace('canceled scheduled disconnection from %s', nodeId)
         }
+    }
+
+    private loggedDisconnect(nodeId: NodeId): void {
+        logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
+        this.disconnect(nodeId, 'no shared streams')
     }
 }

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -1,0 +1,56 @@
+import { NodeId } from './Node'
+import { NameDirectory } from '../../NameDirectory'
+import { DisconnectionReason } from '../../connection/ws/AbstractWsEndpoint'
+import { Logger } from '../../helpers/Logger'
+
+type HasSharedStreamsFn = (neighborId: NodeId) => boolean
+type DisconnectionFn = (neighborId: NodeId, reason: DisconnectionReason) => void
+
+const logger = new Logger(module)
+
+export interface DisconnectionManagerOptions {
+    hasSharedStreams: HasSharedStreamsFn,
+    disconnect: DisconnectionFn,
+    disconnectionDelayInMs: number
+}
+
+export class DisconnectionManager {
+    private readonly disconnectionTimers: Record<NodeId, NodeJS.Timeout> = Object.create(null)
+    private readonly hasSharedStreams: HasSharedStreamsFn
+    private readonly disconnect: DisconnectionFn
+    private readonly disconnectionDelayInMs: number
+
+    constructor({ hasSharedStreams, disconnect, disconnectionDelayInMs }: DisconnectionManagerOptions) {
+        this.hasSharedStreams = hasSharedStreams
+        this.disconnect = disconnect
+        this.disconnectionDelayInMs = disconnectionDelayInMs
+    }
+
+    scheduleDisconnectionIfNoSharedStreams(neighborId: NodeId): void {
+        if (!this.hasSharedStreams(neighborId)) {
+            this.cancelScheduledDisconnection(neighborId)
+            this.disconnectionTimers[neighborId] = setTimeout(() => {
+                delete this.disconnectionTimers[neighborId]
+                if (!this.hasSharedStreams(neighborId)) {
+                    logger.debug('Executing scheduled disconnect from %s', NameDirectory.getName(neighborId))
+                    this.disconnect(neighborId, DisconnectionReason.NO_SHARED_STREAMS)
+                }
+            }, this.disconnectionDelayInMs)
+            logger.trace('Scheduled disconnection from %s in %d ms', neighborId, this.disconnectionDelayInMs)
+        }
+    }
+
+    cancelScheduledDisconnection(neighborId: NodeId): void {
+        if (this.disconnectionTimers[neighborId] != null) {
+            clearTimeout(this.disconnectionTimers[neighborId])
+            delete this.disconnectionTimers[neighborId]
+            logger.trace('Canceled scheduled disconnection from %s', neighborId)
+        }
+    }
+
+    stop(): void {
+        Object.values(this.disconnectionTimers).forEach((timeout) => {
+            clearTimeout(timeout)
+        })
+    }
+}

--- a/packages/network/src/logic/node/DisconnectionManager.ts
+++ b/packages/network/src/logic/node/DisconnectionManager.ts
@@ -1,11 +1,10 @@
 import { NodeId } from './Node'
 import { NameDirectory } from '../../NameDirectory'
-import { DisconnectionReason } from '../../connection/ws/AbstractWsEndpoint'
 import { Logger } from '../../helpers/Logger'
 
 type GetAllNodesFn = () => ReadonlyArray<NodeId>
 type HasSharedStreamsFn = (nodeId: NodeId) => boolean
-type DisconnectionFn = (nodeId: NodeId, reason: DisconnectionReason) => void
+type DisconnectionFn = (nodeId: NodeId, reason: string) => void
 
 const logger = new Logger(module)
 
@@ -48,7 +47,7 @@ export class DisconnectionManager {
                 logger.debug('connectionCleanUpInterval: disconnecting from %d nodes', nonNeighborNodeIds.length)
                 nonNeighborNodeIds.forEach((nodeId) => {
                     logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
-                    this.disconnect(nodeId, DisconnectionReason.NO_SHARED_STREAMS)
+                    this.disconnect(nodeId, 'no shared streams')
                 })
             }
         }, this.cleanUpIntervalInMs)
@@ -68,7 +67,7 @@ export class DisconnectionManager {
                 delete this.disconnectionTimers[nodeId]
                 if (!this.hasSharedStreams(nodeId)) {
                     logger.trace('executing disconnect from %s', NameDirectory.getName(nodeId))
-                    this.disconnect(nodeId, DisconnectionReason.NO_SHARED_STREAMS)
+                    this.disconnect(nodeId, 'no shared streams')
                 }
             }, this.disconnectionDelayInMs)
             logger.trace('scheduled disconnection from %s in %d ms', nodeId, this.disconnectionDelayInMs)

--- a/packages/network/test/unit/DisconnectionManager.test.ts
+++ b/packages/network/test/unit/DisconnectionManager.test.ts
@@ -49,9 +49,9 @@ describe(DisconnectionManager, () => {
             getAllNodes.mockReturnValue(['n1', 'n2', 'n3'])
             await setUpManagerAndRunCleanUpIntervalOnce()
             expect(disconnect).toHaveBeenCalledTimes(3)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'n1', 'no shared streams')
-            expect(disconnect).toHaveBeenNthCalledWith(2, 'n2', 'no shared streams')
-            expect(disconnect).toHaveBeenNthCalledWith(3, 'n3', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n1', DisconnectionManager.DISCONNECTION_REASON)
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n2', DisconnectionManager.DISCONNECTION_REASON)
+            expect(disconnect).toHaveBeenNthCalledWith(3, 'n3', DisconnectionManager.DISCONNECTION_REASON)
         })
 
         it('disconnects from nodes with which no shared streams', async () => {
@@ -59,8 +59,8 @@ describe(DisconnectionManager, () => {
             hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n4'].includes(nodeId))
             await setUpManagerAndRunCleanUpIntervalOnce()
             expect(disconnect).toHaveBeenCalledTimes(2)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'n2', 'no shared streams')
-            expect(disconnect).toHaveBeenNthCalledWith(2, 'n3', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n2', DisconnectionManager.DISCONNECTION_REASON)
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n3', DisconnectionManager.DISCONNECTION_REASON)
         })
 
         it('longer scenario', async () => {
@@ -71,8 +71,8 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n2', 'no shared streams'],
-                ['n3', 'no shared streams']
+                ['n2', DisconnectionManager.DISCONNECTION_REASON],
+                ['n3', DisconnectionManager.DISCONNECTION_REASON]
             ])
 
             disconnect.mockReset()
@@ -81,7 +81,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n3', 'no shared streams']
+                ['n3', DisconnectionManager.DISCONNECTION_REASON]
             ])
 
             disconnect.mockReset()
@@ -90,8 +90,8 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n4', 'no shared streams'],
-                ['n5', 'no shared streams']
+                ['n4', DisconnectionManager.DISCONNECTION_REASON],
+                ['n5', DisconnectionManager.DISCONNECTION_REASON]
             ])
 
             disconnect.mockReset()
@@ -100,7 +100,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n6', 'no shared streams']
+                ['n6', DisconnectionManager.DISCONNECTION_REASON]
             ])
 
             disconnect.mockReset()
@@ -109,7 +109,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n1', 'no shared streams']
+                ['n1', DisconnectionManager.DISCONNECTION_REASON]
             ])
         })
     })
@@ -123,7 +123,7 @@ describe(DisconnectionManager, () => {
             manager.scheduleDisconnectionIfNoSharedStreams('node')
             await wait(TTL + 1)
             expect(disconnect).toHaveBeenCalledTimes(1)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', DisconnectionManager.DISCONNECTION_REASON)
         })
 
         it('not executed after TTL if has shared streams by then', async () => {
@@ -149,7 +149,7 @@ describe(DisconnectionManager, () => {
             expect(disconnect).toHaveBeenCalledTimes(0)
             await wait((TTL / 2) + 1)
             expect(disconnect).toHaveBeenCalledTimes(1)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', DisconnectionManager.DISCONNECTION_REASON)
         })
 
         it('not executed after TTL if canceled before', async () => {
@@ -167,7 +167,7 @@ describe(DisconnectionManager, () => {
             manager.cancelScheduledDisconnection('node-2')
             await wait((TTL / 2) + 1)
             expect(disconnect).toHaveBeenCalledTimes(1)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'node-1', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node-1', DisconnectionManager.DISCONNECTION_REASON)
         })
 
         it('canceling non-existing disconnection does not throw', () => {

--- a/packages/network/test/unit/DisconnectionManager.test.ts
+++ b/packages/network/test/unit/DisconnectionManager.test.ts
@@ -1,6 +1,5 @@
 import { DisconnectionManager } from '../../src/logic/node/DisconnectionManager'
 import { NodeId } from '../../src/logic/node/Node'
-import { DisconnectionReason } from '../../src/connection/ws/AbstractWsEndpoint'
 import { wait } from 'streamr-test-utils'
 
 const TTL = 20
@@ -8,7 +7,7 @@ const TTL = 20
 describe(DisconnectionManager, () => {
     let getAllNodes: jest.Mock<NodeId[], []>
     let hasSharedStreams: jest.Mock<boolean, [NodeId]>
-    let disconnect: jest.Mock<void, [NodeId, DisconnectionReason]>
+    let disconnect: jest.Mock<void, [NodeId, string]>
     let manager: DisconnectionManager
 
     function setUpManager(disconnectionDelayInMs: number, cleanUpIntervalInMs: number): void {
@@ -50,9 +49,9 @@ describe(DisconnectionManager, () => {
             getAllNodes.mockReturnValue(['n1', 'n2', 'n3'])
             await setUpManagerAndRunCleanUpIntervalOnce()
             expect(disconnect).toHaveBeenCalledTimes(3)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'n1', DisconnectionReason.NO_SHARED_STREAMS)
-            expect(disconnect).toHaveBeenNthCalledWith(2, 'n2', DisconnectionReason.NO_SHARED_STREAMS)
-            expect(disconnect).toHaveBeenNthCalledWith(3, 'n3', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n1', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n2', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(3, 'n3', 'no shared streams')
         })
 
         it('disconnects from nodes with which no shared streams', async () => {
@@ -60,8 +59,8 @@ describe(DisconnectionManager, () => {
             hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n4'].includes(nodeId))
             await setUpManagerAndRunCleanUpIntervalOnce()
             expect(disconnect).toHaveBeenCalledTimes(2)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'n2', DisconnectionReason.NO_SHARED_STREAMS)
-            expect(disconnect).toHaveBeenNthCalledWith(2, 'n3', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n2', 'no shared streams')
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n3', 'no shared streams')
         })
 
         it('longer scenario', async () => {
@@ -72,8 +71,8 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n2', DisconnectionReason.NO_SHARED_STREAMS],
-                ['n3', DisconnectionReason.NO_SHARED_STREAMS]
+                ['n2', 'no shared streams'],
+                ['n3', 'no shared streams']
             ])
 
             disconnect.mockReset()
@@ -82,7 +81,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n3', DisconnectionReason.NO_SHARED_STREAMS]
+                ['n3', 'no shared streams']
             ])
 
             disconnect.mockReset()
@@ -91,8 +90,8 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n4', DisconnectionReason.NO_SHARED_STREAMS],
-                ['n5', DisconnectionReason.NO_SHARED_STREAMS]
+                ['n4', 'no shared streams'],
+                ['n5', 'no shared streams']
             ])
 
             disconnect.mockReset()
@@ -101,7 +100,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n6', DisconnectionReason.NO_SHARED_STREAMS]
+                ['n6', 'no shared streams']
             ])
 
             disconnect.mockReset()
@@ -110,7 +109,7 @@ describe(DisconnectionManager, () => {
 
             await wait(TTL + 1)
             expect(disconnect.mock.calls).toEqual([
-                ['n1', DisconnectionReason.NO_SHARED_STREAMS]
+                ['n1', 'no shared streams']
             ])
         })
     })
@@ -124,7 +123,7 @@ describe(DisconnectionManager, () => {
             manager.scheduleDisconnectionIfNoSharedStreams('node')
             await wait(TTL + 1)
             expect(disconnect).toHaveBeenCalledTimes(1)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', 'no shared streams')
         })
 
         it('not executed after TTL if has shared streams by then', async () => {
@@ -157,7 +156,7 @@ describe(DisconnectionManager, () => {
             manager.cancelScheduledDisconnection('node-2')
             await wait((TTL / 2) + 1)
             expect(disconnect).toHaveBeenCalledTimes(1)
-            expect(disconnect).toHaveBeenNthCalledWith(1, 'node-1', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node-1', 'no shared streams')
         })
 
         it('canceling non-existing disconnection does not throw', () => {

--- a/packages/network/test/unit/DisconnectionManager.test.ts
+++ b/packages/network/test/unit/DisconnectionManager.test.ts
@@ -1,0 +1,169 @@
+import { DisconnectionManager } from '../../src/logic/node/DisconnectionManager'
+import { NodeId } from '../../src/logic/node/Node'
+import { DisconnectionReason } from '../../src/connection/ws/AbstractWsEndpoint'
+import { wait } from 'streamr-test-utils'
+
+const TTL = 20
+
+describe(DisconnectionManager, () => {
+    let getAllNodes: jest.Mock<NodeId[], []>
+    let hasSharedStreams: jest.Mock<boolean, [NodeId]>
+    let disconnect: jest.Mock<void, [NodeId, DisconnectionReason]>
+    let manager: DisconnectionManager
+
+    function setUpManager(disconnectionDelayInMs: number, cleanUpIntervalInMs: number): void {
+        manager = new DisconnectionManager({
+            getAllNodes,
+            hasSharedStreams,
+            disconnect,
+            disconnectionDelayInMs,
+            cleanUpIntervalInMs
+        })
+    }
+
+    beforeEach(() => {
+        getAllNodes = jest.fn()
+        hasSharedStreams = jest.fn()
+        disconnect = jest.fn()
+    })
+
+    afterEach(() => {
+        manager?.stop()
+    })
+
+    describe('clean up interval', () => {
+        async function setUpManagerAndRunCleanUpIntervalOnce(): Promise<void> {
+            setUpManager(1000, TTL)
+            manager.start()
+            await wait(TTL + 1)
+            manager?.stop()
+        }
+
+        it('works (noop) with empty values', async () => {
+            getAllNodes.mockReturnValue([])
+            await setUpManagerAndRunCleanUpIntervalOnce()
+            expect(getAllNodes.mock.calls.length).toBeGreaterThanOrEqual(1)
+            expect(disconnect).toHaveBeenCalledTimes(0)
+        })
+
+        it('disconnects from all nodes if no streams', async () => {
+            getAllNodes.mockReturnValue(['n1', 'n2', 'n3'])
+            await setUpManagerAndRunCleanUpIntervalOnce()
+            expect(disconnect).toHaveBeenCalledTimes(3)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n1', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n2', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(3, 'n3', DisconnectionReason.NO_SHARED_STREAMS)
+        })
+
+        it('disconnects from nodes with which no shared streams', async () => {
+            getAllNodes.mockReturnValue(['n1', 'n2', 'n3', 'n4'])
+            hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n4'].includes(nodeId))
+            await setUpManagerAndRunCleanUpIntervalOnce()
+            expect(disconnect).toHaveBeenCalledTimes(2)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'n2', DisconnectionReason.NO_SHARED_STREAMS)
+            expect(disconnect).toHaveBeenNthCalledWith(2, 'n3', DisconnectionReason.NO_SHARED_STREAMS)
+        })
+
+        it('longer scenario', async () => {
+            getAllNodes.mockReturnValue(['n1', 'n2', 'n3', 'n4'])
+            hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n4'].includes(nodeId))
+            setUpManager(1000, TTL)
+            manager.start()
+
+            await wait(TTL + 1)
+            expect(disconnect.mock.calls).toEqual([
+                ['n2', DisconnectionReason.NO_SHARED_STREAMS],
+                ['n3', DisconnectionReason.NO_SHARED_STREAMS]
+            ])
+
+            disconnect.mockReset()
+            getAllNodes.mockReturnValue(['n1', 'n3', 'n4'])
+            hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n4'].includes(nodeId))
+
+            await wait(TTL + 1)
+            expect(disconnect.mock.calls).toEqual([
+                ['n3', DisconnectionReason.NO_SHARED_STREAMS]
+            ])
+
+            disconnect.mockReset()
+            getAllNodes.mockReturnValue(['n1', 'n4', 'n5', 'n6'])
+            hasSharedStreams.mockImplementation((nodeId) => ['n1', 'n6'].includes(nodeId))
+
+            await wait(TTL + 1)
+            expect(disconnect.mock.calls).toEqual([
+                ['n4', DisconnectionReason.NO_SHARED_STREAMS],
+                ['n5', DisconnectionReason.NO_SHARED_STREAMS]
+            ])
+
+            disconnect.mockReset()
+            getAllNodes.mockReturnValue(['n1', 'n6'])
+            hasSharedStreams.mockImplementation((nodeId) => ['n1'].includes(nodeId))
+
+            await wait(TTL + 1)
+            expect(disconnect.mock.calls).toEqual([
+                ['n6', DisconnectionReason.NO_SHARED_STREAMS]
+            ])
+
+            disconnect.mockReset()
+            getAllNodes.mockReturnValue(['n1'])
+            hasSharedStreams.mockImplementation(() => false)
+
+            await wait(TTL + 1)
+            expect(disconnect.mock.calls).toEqual([
+                ['n1', DisconnectionReason.NO_SHARED_STREAMS]
+            ])
+        })
+    })
+
+    describe('scheduled disconnection', () => {
+        beforeEach(() => {
+            setUpManager(TTL, 60 * 60 * 1000)
+        })
+
+        it('executed after TTL if no shared streams then', async () => {
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            await wait(TTL + 1)
+            expect(disconnect).toHaveBeenCalledTimes(1)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', DisconnectionReason.NO_SHARED_STREAMS)
+        })
+
+        it('not executed after TTL if has shared streams by then', async () => {
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            hasSharedStreams.mockReturnValue(true)
+            await wait(TTL + 1)
+            expect(disconnect).toHaveBeenCalledTimes(0)
+        })
+
+        it('not executed after TTL if had shared streams initially', async () => {
+            hasSharedStreams.mockReturnValue(true)
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            hasSharedStreams.mockReturnValue(false)
+            await wait(TTL + 1)
+            expect(disconnect).toHaveBeenCalledTimes(0)
+        })
+
+        it('not executed after TTL if canceled before', async () => {
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            await wait(TTL / 2)
+            manager.cancelScheduledDisconnection('node')
+            await wait((TTL / 2) + 1)
+            expect(disconnect).toHaveBeenCalledTimes(0)
+        })
+
+        it('executed after TTL if canceling other (unrelated) node', async () => {
+            manager.scheduleDisconnectionIfNoSharedStreams('node-1')
+            manager.scheduleDisconnectionIfNoSharedStreams('node-2')
+            await wait(TTL / 2)
+            manager.cancelScheduledDisconnection('node-2')
+            await wait((TTL / 2) + 1)
+            expect(disconnect).toHaveBeenCalledTimes(1)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node-1', DisconnectionReason.NO_SHARED_STREAMS)
+        })
+
+        it('canceling non-existing disconnection does not throw', () => {
+            expect(() => {
+                manager.cancelScheduledDisconnection('non-existing-node')
+            }).not.toThrowError()
+        })
+    })
+})

--- a/packages/network/test/unit/DisconnectionManager.test.ts
+++ b/packages/network/test/unit/DisconnectionManager.test.ts
@@ -141,6 +141,17 @@ describe(DisconnectionManager, () => {
             expect(disconnect).toHaveBeenCalledTimes(0)
         })
 
+        it('re-scheduling same disconnection causes debounce', async () => {
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            await wait(TTL / 2)
+            manager.scheduleDisconnectionIfNoSharedStreams('node')
+            await wait((TTL / 2) + 1)
+            expect(disconnect).toHaveBeenCalledTimes(0)
+            await wait((TTL / 2) + 1)
+            expect(disconnect).toHaveBeenCalledTimes(1)
+            expect(disconnect).toHaveBeenNthCalledWith(1, 'node', 'no shared streams')
+        })
+
         it('not executed after TTL if canceled before', async () => {
             manager.scheduleDisconnectionIfNoSharedStreams('node')
             await wait(TTL / 2)


### PR DESCRIPTION
Again, in furtherance of encapsulation, modularization, and testing, extract node-to-node disconnection logic from `Node` into new class `DisconnectionManager`. 

Wrote a unit test for `DisconnectionManager`.