### PR TITLE
InstructionSender refactor

### DIFF
--- a/packages/network/src/logic/tracker/InstructionSender.ts
+++ b/packages/network/src/logic/tracker/InstructionSender.ts
@@ -3,7 +3,6 @@ import io from '@pm2/io'
 import { Logger } from '../../helpers/Logger'
 import { Metrics } from '../../helpers/MetricsContext'
 import { StreamIdAndPartition, StreamKey } from '../../identifiers'
-import { TrackerServer } from '../../protocol/TrackerServer'
 import { NodeId } from '../node/Node'
 import { TopologyStabilizationOptions } from './Tracker'
 
@@ -23,7 +22,7 @@ import { TopologyStabilizationOptions } from './Tracker'
  * counterValue) and can be ignored.
  */
 
-const DEFAULT_TOPOLOGY_STABILIZATION: TopologyStabilizationOptions = {
+const DEFAULT_TOPOLOGY_STABILIZATION_OPTIONS: TopologyStabilizationOptions = {
     debounceWait: 100,
     maxWait: 2000
 }
@@ -38,12 +37,12 @@ export interface Instruction {
 }
 
 class StreamInstructionBuffer {
-    private instructions: Map<NodeId,Instruction> = new Map()
-    private debouncedOnReady: () => void
+    private readonly instructions = new Map<NodeId, Instruction>()
+    private readonly debouncedOnReady: () => void
 
-    constructor(topologyStabilization: TopologyStabilizationOptions, onReady: () => void) {
-        this.debouncedOnReady = _.debounce(onReady, topologyStabilization.debounceWait, {
-            maxWait: topologyStabilization.maxWait
+    constructor(options: TopologyStabilizationOptions, onReady: () => void) {
+        this.debouncedOnReady = _.debounce(onReady, options.debounceWait, {
+            maxWait: options.maxWait
         })
     }
 
@@ -58,18 +57,29 @@ class StreamInstructionBuffer {
     }
 }
 
-export class InstructionSender {
+export type SendInstructionFn = (
+    receiverNodeId: NodeId,
+    streamId: StreamIdAndPartition,
+    nodeIds: NodeId[],
+    counter: number
+) => Promise<void>
 
-    private readonly streamBuffers: Map<StreamKey,StreamInstructionBuffer> = new Map()
-    private readonly topologyStabilization: TopologyStabilizationOptions
-    private readonly trackerServer: TrackerServer
+export class InstructionSender {
+    private readonly streamBuffers = new Map<StreamKey, StreamInstructionBuffer>()
+    private readonly options: TopologyStabilizationOptions
+    private readonly sendInstruction: SendInstructionFn
     private readonly metrics: Metrics
     private readonly pm2Meter: any
 
-    constructor(topologyStabilization: TopologyStabilizationOptions|undefined, trackerServer: TrackerServer, metrics: Metrics) {
-        this.topologyStabilization = topologyStabilization ?? DEFAULT_TOPOLOGY_STABILIZATION
-        this.trackerServer = trackerServer
+    constructor(
+        options: TopologyStabilizationOptions | undefined,
+        sendInstruction: SendInstructionFn,
+        metrics: Metrics
+    ) {
+        this.options = options ?? DEFAULT_TOPOLOGY_STABILIZATION_OPTIONS
+        this.sendInstruction = sendInstruction
         this.metrics = metrics
+            .addRecordedMetric('instructionsSent')
         this.pm2Meter = io.meter({
             name: 'instructions/sec'
         })
@@ -79,12 +89,12 @@ export class InstructionSender {
         this.getOrCreateBuffer(instruction.streamKey).addInstruction(instruction)
     }
 
-    getOrCreateBuffer(streamKey: StreamKey): StreamInstructionBuffer {
+    private getOrCreateBuffer(streamKey: StreamKey): StreamInstructionBuffer {
         const existingBuffer = this.streamBuffers.get(streamKey)
         if (existingBuffer !== undefined) {
             return existingBuffer
         } else {
-            const newBuffer = new StreamInstructionBuffer(this.topologyStabilization, () => {
+            const newBuffer = new StreamInstructionBuffer(this.options, () => {
                 this.streamBuffers.delete(streamKey)
                 this.sendInstructions(newBuffer)
             })
@@ -93,22 +103,29 @@ export class InstructionSender {
         }
     }
 
-    private async sendInstructions(buffer: StreamInstructionBuffer) {
-        for (const instruction of buffer!.getInstructions()) {
-            const { nodeId, streamKey, newNeighbors, counterValue } = instruction
+    private async sendInstructions(buffer: StreamInstructionBuffer): Promise<void> {
+        const promises: Promise<void>[] = []
+        for (const { nodeId, streamKey, newNeighbors, counterValue } of buffer.getInstructions()) {
             this.metrics.record('instructionsSent', 1)
             this.pm2Meter.mark()
-            try {
-                await this.trackerServer.sendInstruction(
-                    nodeId,
-                    StreamIdAndPartition.fromKey(streamKey),
-                    newNeighbors,
-                    counterValue
-                )
-                logger.debug('Instruction %o sent to node %o', newNeighbors, { counterValue, streamKey, nodeId })
-            } catch (err) {
-                logger.error(`Failed to send instructions %o to node %o, reason: %s`, newNeighbors, { counterValue, streamKey, nodeId }, err)
-            }
+            promises.push((async () => {
+                try {
+                    await this.sendInstruction(
+                        nodeId,
+                        StreamIdAndPartition.fromKey(streamKey),
+                        newNeighbors,
+                        counterValue
+                    )
+                    logger.debug('instruction %o sent to node %o', newNeighbors, { counterValue, streamKey, nodeId })
+                } catch (err) {
+                    logger.error(`failed to send instructions %o to node %o, reason: %s`,
+                        newNeighbors,
+                        { counterValue, streamKey, nodeId },
+                        err
+                    )
+                }
+            })())
         }
+        await Promise.allSettled(promises)
     }
 }

--- a/packages/network/src/logic/tracker/InstructionSender.ts
+++ b/packages/network/src/logic/tracker/InstructionSender.ts
@@ -104,11 +104,10 @@ export class InstructionSender {
     }
 
     private async sendInstructions(buffer: StreamInstructionBuffer): Promise<void> {
-        const promises: Promise<void>[] = []
-        for (const { nodeId, streamKey, newNeighbors, counterValue } of buffer.getInstructions()) {
-            this.metrics.record('instructionsSent', 1)
-            this.pm2Meter.mark()
-            promises.push((async () => {
+        const promises = Array.from(buffer.getInstructions())
+            .map(async ({ nodeId, streamKey, newNeighbors, counterValue }) => {
+                this.metrics.record('instructionsSent', 1)
+                this.pm2Meter.mark()
                 try {
                     await this.sendInstruction(
                         nodeId,
@@ -124,8 +123,7 @@ export class InstructionSender {
                         err
                     )
                 }
-            })())
-        }
+            })
         await Promise.allSettled(promises)
     }
 }

--- a/packages/network/src/logic/tracker/Tracker.ts
+++ b/packages/network/src/logic/tracker/Tracker.ts
@@ -99,7 +99,6 @@ export class Tracker extends EventEmitter {
         this.metrics = metricsContext.create('tracker')
             .addRecordedMetric('onNodeDisconnected')
             .addRecordedMetric('processNodeStatus')
-            .addRecordedMetric('instructionsSent')
             .addRecordedMetric('_removeNode')
 
         this.statusMeter = io.meter({

--- a/packages/network/src/logic/tracker/Tracker.ts
+++ b/packages/network/src/logic/tracker/Tracker.ts
@@ -105,7 +105,11 @@ export class Tracker extends EventEmitter {
             name: 'statuses/sec'
         })
 
-        this.instructionSender = new InstructionSender(opts.topologyStabilization, this.trackerServer, this.metrics)
+        this.instructionSender = new InstructionSender(
+            opts.topologyStabilization,
+            this.trackerServer.sendInstruction.bind(this.trackerServer),
+            this.metrics
+        )
     }
 
     onNodeConnected(node: NodeId): void {

--- a/packages/network/test/unit/InstructionSender.test.ts
+++ b/packages/network/test/unit/InstructionSender.test.ts
@@ -1,5 +1,6 @@
-import { Instruction, InstructionSender } from '../../src/logic/tracker/InstructionSender'
-import { StreamKey } from '../../src/identifiers'
+import { Instruction, InstructionSender, SendInstructionFn } from '../../src/logic/tracker/InstructionSender'
+import { StreamIdAndPartition, StreamKey } from '../../src/identifiers'
+import { Metrics, MetricsContext } from '../../src/helpers/MetricsContext'
 
 const MOCK_STREAM_1 = 'stream-id::1'
 const MOCK_STREAM_2 = 'stream-id::2'
@@ -10,34 +11,30 @@ const MAX_WAIT = 2000
 
 let mockInstructionIdSuffix = 0
 
-const createMockInstruction = (streamKey: StreamKey) => {
+const createMockInstruction = (streamKey: StreamKey): Instruction => {
     mockInstructionIdSuffix++
     return {
         nodeId: `mock-node-id-${mockInstructionIdSuffix}`,
-        streamKey
-    } as any
-}
-
-const assertEqualInstructions = (
-    callArgs: [buffer: { getInstructions: () => IterableIterator<Instruction>}],
-    expected: Instruction[]
-) => {
-    const actual = Array.from(callArgs[0].getInstructions())
-    expect(actual).toEqual(expected)
+        streamKey,
+        newNeighbors: [],
+        counterValue: 0
+    }
 }
 
 describe('InstructionSender', () => {
-    let sender: any
-    let send: any
+    let metrics: Metrics
+    let send: jest.Mock<ReturnType<SendInstructionFn>, Parameters<SendInstructionFn>>
+    let sender: InstructionSender
 
     beforeEach(() => {
         jest.useFakeTimers()
         jest.setSystemTime(STARTUP_TIME)
+        metrics = new MetricsContext('').create('test')
+        send = jest.fn().mockResolvedValue(true)
         sender = new InstructionSender({
             debounceWait: DEBOUNCE_WAIT,
             maxWait: MAX_WAIT
-        }, undefined as any, undefined as any) as any
-        send = jest.spyOn(sender, 'sendInstructions').mockResolvedValue(undefined) as any
+        }, send, metrics)
     })
 
     afterEach(() => {
@@ -45,13 +42,21 @@ describe('InstructionSender', () => {
         jest.useRealTimers()
     })
 
+    function assertSendsCalled(instructions: readonly Instruction[]): void {
+        expect(send).toBeCalledTimes(instructions.length)
+        for (let i = 0; i < instructions.length; ++i) {
+            const { nodeId, streamKey, newNeighbors, counterValue } = instructions[i]
+            const stream = StreamIdAndPartition.fromKey(streamKey)
+            expect(send).toHaveBeenNthCalledWith(i + 1, nodeId, stream, newNeighbors, counterValue)
+        }
+    }
+
     it('wait stabilization', () => {
         const instruction = createMockInstruction(MOCK_STREAM_1)
         sender.addInstruction(instruction)
         expect(send).not.toBeCalled()
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
-        expect(send).toBeCalledTimes(1)
-        assertEqualInstructions(send.mock.calls[0], [ instruction ])
+        assertSendsCalled([instruction])
     })
 
     it('add within stabilization wait', () => {
@@ -61,8 +66,7 @@ describe('InstructionSender', () => {
         const instruction2 = createMockInstruction(MOCK_STREAM_1)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
-        expect(send).toBeCalledTimes(1)
-        assertEqualInstructions(send.mock.calls[0], [ instruction1, instruction2 ])
+        assertSendsCalled([instruction1, instruction2])
     })
 
     it('add after stabilization wait', () => {
@@ -72,8 +76,7 @@ describe('InstructionSender', () => {
         const instruction2 = createMockInstruction(MOCK_STREAM_1)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
-        expect(send).toBeCalledTimes(2)
-        assertEqualInstructions(send.mock.calls[1], [ instruction2 ])
+        assertSendsCalled([instruction1, instruction2])
     })
 
     it('max wait reached', () => {
@@ -84,8 +87,7 @@ describe('InstructionSender', () => {
             expected.push(instruction)
             jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
         }
-        expect(send).toBeCalledTimes(1)
-        assertEqualInstructions(send.mock.calls[0], expected)
+        assertSendsCalled(expected)
     })
 
     it('independent stream buffers', () => {
@@ -95,8 +97,6 @@ describe('InstructionSender', () => {
         const instruction2 = createMockInstruction(MOCK_STREAM_2)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
-        expect(send).toBeCalledTimes(2)
-        assertEqualInstructions(send.mock.calls[0], [ instruction1 ])
-        assertEqualInstructions(send.mock.calls[1], [ instruction2 ])
+        assertSendsCalled([instruction1, instruction2])
     })
 })


### PR DESCRIPTION
- Some refactoring of `InstructionSender`
- Slight *modification to behaviour*: it will send a stream's instructions to all nodes concurrently as opposed to one-by-one.