### PR TITLE
network, broker [NET-518]: replace StreamIdAndPartition with SPID

### DIFF
--- a/packages/broker/jest.config.js
+++ b/packages/broker/jest.config.js
@@ -22,5 +22,7 @@ module.exports = {
     testEnvironment: 'node',
 
     // Default timeout of a test in milliseconds
-    testTimeout: 10000
+    testTimeout: 10000,
+
+    setupFilesAfterEnv: ["jest-extended"]
 }

--- a/packages/broker/package-lock.json
+++ b/packages/broker/package-lock.json
@@ -2124,6 +2124,24 @@
 				}
 			}
 		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2140,10 +2158,22 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"astral-regex": {
 			"version": "2.0.0",
@@ -2188,6 +2218,12 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
 		},
 		"atomic-sleep": {
 			"version": "1.0.0",
@@ -2278,6 +2314,61 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
 		},
 		"base64-js": {
 			"version": "1.5.1",
@@ -2459,6 +2550,23 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
 		"call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2546,6 +2654,29 @@
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
 			"dev": true
 		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
 		"cli-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2591,6 +2722,16 @@
 			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -2712,6 +2853,12 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
 			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+			"dev": true
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
 		"core-util-is": {
@@ -2917,6 +3064,47 @@
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"requires": {
 				"clone": "^1.0.2"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
 			}
 		},
 		"delayed-stream": {
@@ -3543,6 +3731,56 @@
 			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
 			"dev": true
 		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"expect": {
 			"version": "27.2.4",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-27.2.4.tgz",
@@ -3642,6 +3880,27 @@
 				}
 			}
 		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -3650,6 +3909,71 @@
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
 			}
 		},
 		"fast-deep-equal": {
@@ -3831,6 +4155,12 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
 			"integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
 		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
 		"form-data": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -3851,6 +4181,15 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
 		},
 		"fresh": {
 			"version": "0.5.2",
@@ -3961,6 +4300,12 @@
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true
 		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
 		"glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4037,6 +4382,58 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -4268,6 +4665,26 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4295,10 +4712,55 @@
 				"has": "^1.0.3"
 			}
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
 		"is-electron": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
 			"integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -4394,6 +4856,12 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -4621,6 +5089,405 @@
 				"@types/node": "*",
 				"jest-mock": "^27.2.4",
 				"jest-util": "^27.2.4"
+			}
+		},
+		"jest-extended": {
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.5.tgz",
+			"integrity": "sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==",
+			"dev": true,
+			"requires": {
+				"expect": "^24.1.0",
+				"jest-get-type": "^22.4.3",
+				"jest-matcher-utils": "^22.0.0"
+			},
+			"dependencies": {
+				"@jest/console": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+					"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+					"dev": true,
+					"requires": {
+						"@jest/source-map": "^24.9.0",
+						"chalk": "^2.0.1",
+						"slash": "^2.0.0"
+					}
+				},
+				"@jest/source-map": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+					"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.1.15",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+					"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/istanbul-lib-coverage": "^2.0.0"
+					}
+				},
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/stack-utils": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+					"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+					"dev": true
+				},
+				"@types/yargs": {
+					"version": "13.0.12",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+					"integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+					"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+					"dev": true
+				},
+				"expect": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+					"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-styles": "^3.2.0",
+						"jest-get-type": "^24.9.0",
+						"jest-matcher-utils": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-regex-util": "^24.9.0"
+					},
+					"dependencies": {
+						"jest-get-type": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+							"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+							"dev": true
+						},
+						"jest-matcher-utils": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+							"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+							"dev": true,
+							"requires": {
+								"chalk": "^2.0.1",
+								"jest-diff": "^24.9.0",
+								"jest-get-type": "^24.9.0",
+								"pretty-format": "^24.9.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"jest-diff": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+					"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					},
+					"dependencies": {
+						"jest-get-type": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+							"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+							"dev": true
+						}
+					}
+				},
+				"jest-get-type": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+					"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+					"dev": true
+				},
+				"jest-matcher-utils": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"pretty-format": {
+							"version": "22.4.3",
+							"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+							"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0",
+								"ansi-styles": "^3.2.0"
+							}
+						}
+					}
+				},
+				"jest-message-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+					"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^2.0.1",
+						"micromatch": "^3.1.10",
+						"slash": "^2.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-regex-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+					"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"stack-utils": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.5.tgz",
+					"integrity": "sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^2.0.0"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+							"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+							"dev": true
+						}
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
 			}
 		},
 		"jest-get-type": {
@@ -5141,6 +6008,12 @@
 			"integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
 			"dev": true
 		},
+		"kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true
+		},
 		"kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5291,10 +6164,25 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -5420,6 +6308,27 @@
 				"is-plain-obj": "^1.1.0"
 			}
 		},
+		"mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"module-details-from-path": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
@@ -5529,6 +6438,25 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
 		},
 		"nat-type-identifier": {
 			"version": "2.0.11",
@@ -5701,10 +6629,59 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"object-inspect": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
 			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"omggif": {
 			"version": "1.0.10",
@@ -5890,6 +6867,12 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -6063,6 +7046,12 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
 			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -6251,6 +7240,16 @@
 				"strip-indent": "^2.0.0"
 			}
 		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
 		"regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -6261,6 +7260,18 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
 			"integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
 		"require-directory": {
@@ -6316,6 +7327,12 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
 		"restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -6324,6 +7341,12 @@
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
 			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"retimer": {
 			"version": "3.0.0",
@@ -6380,6 +7403,15 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -6456,6 +7488,29 @@
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
 				"send": "0.17.1"
+			}
+		},
+		"set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"setimmediate": {
@@ -6546,6 +7601,134 @@
 				"is-fullwidth-code-point": "^3.0.0"
 			}
 		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"sonic-boom": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.0.tgz",
@@ -6560,6 +7743,19 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true
 		},
+		"source-map-resolve": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
 		"source-map-support": {
 			"version": "0.5.20",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
@@ -6569,6 +7765,12 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"source-map-url": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -6603,6 +7805,15 @@
 			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
 			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
 		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
 		"split2": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -6631,6 +7842,27 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
+				}
+			}
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
 				}
 			}
 		},
@@ -6957,6 +8189,38 @@
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7103,6 +8367,18 @@
 			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
 			"dev": true
 		},
+		"union-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			}
+		},
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -7118,6 +8394,46 @@
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7125,6 +8441,18 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"utf8-binary-cutter": {
 			"version": "0.9.2",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -91,6 +91,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "jest": "^27.0.5",
     "jest-circus": "^27.0.5",
+    "jest-extended": "^0.11.5",
     "nock": "^13.1.3",
     "sinon": "^11.1.1",
     "stream-to-array": "^2.3.0",

--- a/packages/broker/src/Stream.ts
+++ b/packages/broker/src/Stream.ts
@@ -54,7 +54,7 @@ export class Stream<C> {
     }
 
     getSPIDKey(): Protocol.SPIDKey {
-        return new Protocol.SPID(this.id, this.partition).toKey()
+        return Protocol.SPID.toKey(this.id, this.partition)
     }
 
     getName(): string {

--- a/packages/broker/src/Stream.ts
+++ b/packages/broker/src/Stream.ts
@@ -1,5 +1,4 @@
 import { Protocol } from 'streamr-network'
-import { SPID } from 'streamr-network/dist/streamr-protocol'
 
 type State = 'init'|'subscribing'|'subscribed'
 
@@ -55,7 +54,7 @@ export class Stream<C> {
     }
 
     getSPIDKey(): Protocol.SPIDKey {
-        return new SPID(this.id, this.partition).toKey()
+        return new Protocol.SPID(this.id, this.partition).toKey()
     }
 
     getName(): string {

--- a/packages/broker/src/Stream.ts
+++ b/packages/broker/src/Stream.ts
@@ -1,3 +1,6 @@
+import { Protocol } from 'streamr-network'
+import { SPID } from 'streamr-network/dist/streamr-protocol'
+
 type State = 'init'|'subscribing'|'subscribed'
 
 export class Stream<C> {
@@ -51,8 +54,8 @@ export class Stream<C> {
         return this.state === 'subscribed'
     }
 
-    toString(): string {
-        return `${this.id}::${this.partition}`
+    getSPIDKey(): Protocol.SPIDKey {
+        return new SPID(this.id, this.partition).toKey()
     }
 
     getName(): string {

--- a/packages/broker/src/StreamStateManager.ts
+++ b/packages/broker/src/StreamStateManager.ts
@@ -16,7 +16,7 @@ export class StreamStateManager<C> {
     }
 
     get(streamId: string, streamPartition: number): Stream<C> {
-        const key = new Protocol.SPID(streamId, streamPartition).toKey()
+        const key = Protocol.SPID.toKey(streamId, streamPartition)
         return this.streams[key]
     }
 
@@ -34,7 +34,7 @@ export class StreamStateManager<C> {
             throw new Error('streamId or streamPartition not given!')
         }
 
-        const key = new Protocol.SPID(streamId, streamPartition).toKey()
+        const key = Protocol.SPID.toKey(streamId, streamPartition)
         if (this.streams[key]) {
             throw new Error(`stream already exists for ${key}`)
         }
@@ -70,7 +70,7 @@ export class StreamStateManager<C> {
 
         const stream = this.get(streamId, streamPartition)
         if (stream) {
-            const key = new Protocol.SPID(streamId, streamPartition).toKey()
+            const key = Protocol.SPID.toKey(streamId, streamPartition)
             clearTimeout(this.timeouts[key])
             delete this.timeouts[key]
             delete this.streams[key]

--- a/packages/broker/src/SubscriptionManager.ts
+++ b/packages/broker/src/SubscriptionManager.ts
@@ -1,4 +1,5 @@
 import { NetworkNode, Protocol } from 'streamr-network'
+
 export class SubscriptionManager {
     streams = new Map<Protocol.SPIDKey, number>()
 
@@ -6,13 +7,13 @@ export class SubscriptionManager {
     }
 
     subscribe(streamId: string, streamPartition = 0): void {
-        const key = new Protocol.SPID(streamId, streamPartition).toKey()
+        const key = Protocol.SPID.toKey(streamId, streamPartition)
         this.streams.set(key, this.streams.get(key) || 0)
         this.networkNode.subscribe(streamId, streamPartition)
     }
 
     unsubscribe(streamId: string, streamPartition = 0): void {
-        const key = new Protocol.SPID(streamId, streamPartition).toKey()
+        const key = Protocol.SPID.toKey(streamId, streamPartition)
         this.streams.set(key, (this.streams.get(key) || 0) - 1)
 
         if ((this.streams.get(key) || 0) <= 0) {

--- a/packages/broker/src/SubscriptionManager.ts
+++ b/packages/broker/src/SubscriptionManager.ts
@@ -1,19 +1,18 @@
-import { NetworkNode } from 'streamr-network'
-
+import { NetworkNode, Protocol } from 'streamr-network'
 export class SubscriptionManager {
-    streams = new Map<string, number>()
+    streams = new Map<Protocol.SPIDKey, number>()
 
     constructor(public networkNode: NetworkNode) {
     }
 
     subscribe(streamId: string, streamPartition = 0): void {
-        const key = `${streamId}::${streamPartition}`
+        const key = new Protocol.SPID(streamId, streamPartition).toKey()
         this.streams.set(key, this.streams.get(key) || 0)
         this.networkNode.subscribe(streamId, streamPartition)
     }
 
     unsubscribe(streamId: string, streamPartition = 0): void {
-        const key = `${streamId}::${streamPartition}`
+        const key = new Protocol.SPID(streamId, streamPartition).toKey()
         this.streams.set(key, (this.streams.get(key) || 0) - 1)
 
         if ((this.streams.get(key) || 0) <= 0) {

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -1,7 +1,6 @@
-import { Protocol, MetricsContext } from 'streamr-network'
+import { Logger, Protocol, MetricsContext } from 'streamr-network'
 import StreamrClient from 'streamr-client'
 import { Wallet } from 'ethers'
-import { Logger } from 'streamr-network'
 import { Server as HttpServer } from 'http'
 import { Server as HttpsServer } from 'https'
 import { Publisher } from './Publisher'
@@ -20,7 +19,7 @@ const logger = new Logger(module)
 
 export interface Broker {
     getNeighbors: () => readonly string[]
-    getStreams: () => readonly string[]
+    getSPIDs: () => Iterable<Protocol.SPID>
     getNodeId: () => string
     start: () => Promise<unknown>
     stop: () => Promise<unknown>
@@ -127,7 +126,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
 
     return {
         getNeighbors: () => networkNode.getNeighbors(),
-        getStreams: () => networkNode.getStreams(),
+        getSPIDs: () => networkNode.getSPIDs(),
         getNodeId: () => networkNode.getNodeId(),
         start: async () => {
             logger.info(`Starting broker version ${CURRENT_VERSION}`)

--- a/packages/broker/src/plugins/legacyMqtt/Connection.ts
+++ b/packages/broker/src/plugins/legacyMqtt/Connection.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import StrictEventEmitter from 'strict-event-emitter-types'
-import { Logger } from 'streamr-network'
+import { Logger, Protocol } from 'streamr-network'
 import mqttCon from "mqtt-connection"
 import { Stream } from "../../Stream"
 import * as mqtt from "mqtt-packet"
@@ -134,8 +134,8 @@ export class Connection extends ConnectionEmitter {
         return this.streams.slice() // return copy
     }
 
-    streamsAsString(): string[] {
-        return this.streams.map((s) => s.toString())
+    streamsAsString(): Protocol.SPIDKey[] {
+        return this.streams.map((s) => s.getSPIDKey())
     }
 }
 

--- a/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
@@ -303,7 +303,7 @@ export class MqttServer extends EventEmitter {
             this.metrics.record('outBytes', streamMessage.getSerializedContent().length * stream.getConnections().length)
             this.metrics.record('outMessages', stream.getConnections().length)
         } else {
-            logger.debug('broadcastMessage: stream "%s" not found', new Protocol.SPID(streamId, streamPartition).toKey())
+            logger.debug('broadcastMessage: stream "%s" not found', Protocol.SPID.toKey(streamId, streamPartition))
         }
     }
 }

--- a/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
@@ -1,7 +1,7 @@
 import { Server, Socket } from 'net'
 import { EventEmitter } from 'events'
 import mqttCon from 'mqtt-connection'
-import { Metrics, MetricsContext, NetworkNode } from 'streamr-network'
+import { Metrics, MetricsContext, NetworkNode, Protocol } from 'streamr-network'
 import { StreamMessage, MessageID } from 'streamr-network/dist/streamr-protocol'
 import { Logger } from 'streamr-network'
 import { partition } from '../../helpers/partition'
@@ -304,7 +304,7 @@ export class MqttServer extends EventEmitter {
             this.metrics.record('outBytes', streamMessage.getSerializedContent().length * stream.getConnections().length)
             this.metrics.record('outMessages', stream.getConnections().length)
         } else {
-            logger.debug('broadcastMessage: stream "%s::%d" not found', streamId, streamPartition)
+            logger.debug('broadcastMessage: stream "%s" not found', new Protocol.SPID(streamId, streamPartition).toKey())
         }
     }
 }

--- a/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttServer.ts
@@ -2,7 +2,6 @@ import { Server, Socket } from 'net'
 import { EventEmitter } from 'events'
 import mqttCon from 'mqtt-connection'
 import { Metrics, MetricsContext, NetworkNode, Protocol } from 'streamr-network'
-import { StreamMessage, MessageID } from 'streamr-network/dist/streamr-protocol'
 import { Logger } from 'streamr-network'
 import { partition } from '../../helpers/partition'
 import { Publisher } from '../../Publisher'
@@ -178,8 +177,8 @@ export class MqttServer extends EventEmitter {
 
             const textPayload = payload.toString()
             sequenceNumber += 1
-            const streamMessage = new StreamMessage({
-                messageId: new MessageID(streamObj.id, streamPartition, Date.now(), sequenceNumber, connection.id, connection.id),
+            const streamMessage = new Protocol.StreamMessage({
+                messageId: new Protocol.MessageID(streamObj.id, streamPartition, Date.now(), sequenceNumber, connection.id, connection.id),
                 content: mqttPayloadToObject(textPayload),
             })
 
@@ -285,7 +284,7 @@ export class MqttServer extends EventEmitter {
         connection.close()
     }
 
-    broadcastMessage(streamMessage: StreamMessage): void {
+    broadcastMessage(streamMessage: Protocol.StreamMessage): void {
         const streamId = streamMessage.getStreamId()
         const streamPartition = streamMessage.getStreamPartition()
         const stream = this.streams.get(streamId, 0)

--- a/packages/broker/src/plugins/legacyWebsocket/Connection.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/Connection.ts
@@ -120,8 +120,8 @@ export class Connection extends EventEmitter {
         this.getStreams().forEach(cb)
     }
 
-    getStreamsAsString(): string[] {
-        return this.streams.map((s: Stream<Connection>) => s.toString())
+    getStreamsAsString(): Protocol.SPIDKey[] {
+        return this.streams.map((s: Stream<Connection>) => s.getSPIDKey())
     }
 
     ping(): void {

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -12,7 +12,7 @@ export interface StorageConfigListener {
 const getSPIDKeys = (streamId: string, partitions: number): Protocol.SPIDKey[] => {
     const keys: Protocol.SPIDKey[] = []
     for (let i = 0; i < partitions; i++) {
-        keys.push(new Protocol.SPID(streamId, i).toKey())
+        keys.push(Protocol.SPID.toKey(streamId, i))
     }
     return keys
 }
@@ -85,7 +85,7 @@ export class StorageConfig {
     }
 
     hasSPID(spid: Protocol.SPID): boolean {
-        const key = new Protocol.SPID(spid.streamId, spid.streamPartition).toKey()
+        const key = Protocol.SPID.toKey(spid.streamId, spid.streamPartition)
         return this.spidKeys.has(key)
     }
 

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch'
-import { Logger } from 'streamr-network'
+import { Logger, Protocol } from 'streamr-network'
 import { StreamPart } from '../../types'
-import { StreamMessage, keyToArrayIndex } from 'streamr-network/dist/streamr-protocol'
 import { SubscriptionManager } from '../../SubscriptionManager'
 
 const logger = new Logger(module)
@@ -162,13 +161,16 @@ export class StorageConfig {
     }
 
     private belongsToMeInCluster(key: StreamKey): boolean {
-        const hashedIndex = keyToArrayIndex(this.clusterSize, key.toString())
+        const hashedIndex = Protocol.keyToArrayIndex(this.clusterSize, key.toString())
         return hashedIndex === this.myIndexInCluster
     }
 
-    startAssignmentEventListener(streamrAddress: string, subscriptionManager: SubscriptionManager): (msg: StreamMessage<AssignmentMessage>) => void {
+    startAssignmentEventListener(
+        streamrAddress: string, 
+        subscriptionManager: SubscriptionManager): (msg: Protocol.StreamMessage<AssignmentMessage>
+    ) => void {
         const assignmentStreamId = this.getAssignmentStreamId(streamrAddress)
-        const messageListener = (msg: StreamMessage<AssignmentMessage>) => {
+        const messageListener = (msg: Protocol.StreamMessage<AssignmentMessage>) => {
             if (msg.messageId.streamId === assignmentStreamId) {
                 const content = msg.getParsedContent() as any
                 const keys = new Set(getKeysFromStream(content.stream.id, content.stream.partitions))
@@ -207,7 +209,7 @@ export class StorageConfig {
     }
 
     stopAssignmentEventListener(
-        messageListener: (msg: StreamMessage<AssignmentMessage>) => void,
+        messageListener: (msg: Protocol.StreamMessage<AssignmentMessage>) => void,
         streamrAddress: string,
         subscriptionManager: SubscriptionManager
     ): void {

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -131,7 +131,7 @@ export class StorageConfig {
     }
 
     private addSPIDKeys(keysToAdd: Set<Protocol.SPIDKey>): void {
-        logger.info('Add %d SPIDs to storage config: %s', keysToAdd.size, Array.from(keysToAdd).join(','))
+        logger.info('Add %d partitions to storage config: %s', keysToAdd.size, Array.from(keysToAdd).join(','))
         this.spidKeys = new Set([...this.spidKeys, ...keysToAdd])
         this.listeners.forEach((listener) => {
             keysToAdd.forEach((key: Protocol.SPIDKey) => listener.onSPIDAdded(Protocol.SPID.from(key)))
@@ -139,7 +139,7 @@ export class StorageConfig {
     }
 
     private removeSPIDKeys(keysToRemove: Set<Protocol.SPIDKey>): void {
-        logger.info('Remove %d SPIDs from storage config: %s', keysToRemove.size, Array.from(keysToRemove).join(','))
+        logger.info('Remove %d partitions from storage config: %s', keysToRemove.size, Array.from(keysToRemove).join(','))
         this.spidKeys = new Set([...this.spidKeys].filter((x) => !keysToRemove.has(x)))
         this.listeners.forEach((listener) => {
             keysToRemove.forEach((key: Protocol.SPIDKey) => listener.onSPIDRemoved(Protocol.SPID.from(key)))

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -1,37 +1,19 @@
 import fetch from 'node-fetch'
 import { Logger, Protocol } from 'streamr-network'
-import { StreamPart } from '../../types'
+import { SPID } from 'streamr-network/dist/streamr-protocol'
 import { SubscriptionManager } from '../../SubscriptionManager'
 
 const logger = new Logger(module)
 
-type StreamKey = string
-
 export interface StorageConfigListener {
-    onStreamAdded: (streamPart: StreamPart) => void
-    onStreamRemoved: (streamPart: StreamPart) => void
+    onSPIDAdded: (spid: Protocol.SPID) => void
+    onSPIDRemoved: (spid: Protocol.SPID) => void
 }
 
-/*
- * Connects to Core API and queries the configuration there.
- * Refreshes the config at regular intervals.
- */
-const getStreamFromKey = (key: StreamKey): StreamPart => {
-    const [id, partitionStr] = key.split('::')
-    return {
-        id,
-        partition: Number(partitionStr)
-    }
-}
-
-const getKeyFromStream = (streamId: string, streamPartition: number): StreamKey => {
-    return `${streamId}::${streamPartition}`
-}
-
-const getKeysFromStream = (streamId: string, partitions: number): StreamKey[] => {
-    const keys: StreamKey[] = []
+const getSPIDKeys = (streamId: string, partitions: number): Protocol.SPIDKey[] => {
+    const keys: Protocol.SPIDKey[] = []
     for (let i = 0; i < partitions; i++) {
-        keys.push(getKeyFromStream(streamId, i))
+        keys.push(new Protocol.SPID(streamId, i).toKey())
     }
     return keys
 }
@@ -48,7 +30,7 @@ export class StorageConfig {
 
     static ASSIGNMENT_EVENT_STREAM_ID_SUFFIX = '/storage-node-assignments'
 
-    streamKeys: Set<StreamKey>
+    private spidKeys: Set<Protocol.SPIDKey>
     listeners: StorageConfigListener[]
     clusterId: string
     clusterSize: number
@@ -59,7 +41,7 @@ export class StorageConfig {
 
     // use createInstance method instead: it fetches the up-to-date config from API
     constructor(clusterId: string, clusterSize: number, myIndexInCluster: number, apiUrl: string) {
-        this.streamKeys = new Set<StreamKey>()
+        this.spidKeys = new Set<Protocol.SPIDKey>()
         this.listeners = []
         this.clusterId = clusterId
         this.clusterSize = clusterSize
@@ -83,6 +65,10 @@ export class StorageConfig {
         return instance
     }
 
+    /*
+     * Connects to Core API and queries the configuration there.
+     * Refreshes the config at regular intervals.
+     */
     private async poll(pollInterval: number): Promise<void> {
         if (this.stopPoller) { return }
 
@@ -99,13 +85,13 @@ export class StorageConfig {
         this.poller = setTimeout(() => this.poll(pollInterval), pollInterval)
     }
 
-    hasStream(stream: StreamPart): boolean {
-        const key = getKeyFromStream(stream.id, stream.partition)
-        return this.streamKeys.has(key)
+    hasSPID(spid: Protocol.SPID): boolean {
+        const key = new Protocol.SPID(spid.streamId, spid.streamPartition).toKey()
+        return this.spidKeys.has(key)
     }
 
-    getStreams(): StreamPart[] {
-        return Array.from(this.streamKeys).map((key) => getStreamFromKey(key))
+    getSPIDs(): Protocol.SPID[] {
+        return Array.from(this.spidKeys, (key) => SPID.from(key))
     }
 
     addChangeListener(listener: StorageConfigListener): void {
@@ -122,45 +108,45 @@ export class StorageConfig {
             throw new Error(`Invalid response. Refresh failed: ${json}`)
         }
 
-        const streamKeys = new Set<StreamKey>(
+        const spidKeys = new Set<Protocol.SPIDKey>(
             json.flatMap((stream: { id: string, partitions: number }) => ([
-                ...getKeysFromStream(stream.id, stream.partitions)
-            ])).filter ((key: StreamKey) => this.belongsToMeInCluster(key))
+                ...getSPIDKeys(stream.id, stream.partitions)
+            ])).filter ((key: Protocol.SPIDKey) => this.belongsToMeInCluster(key))
         )
-        this.setStreams(streamKeys)
+        this.setSPIDKeys(spidKeys)
     }
 
-    private setStreams(newKeys: Set<StreamKey>): void {
-        const oldKeys = this.streamKeys
+    private setSPIDKeys(newKeys: Set<Protocol.SPIDKey>): void {
+        const oldKeys = this.spidKeys
         const added = new Set([...newKeys].filter((x) => !oldKeys.has(x)))
         const removed = new Set([...oldKeys].filter((x) => !newKeys.has(x)))
 
         if (added.size > 0) {
-            this.addStreams(added)
+            this.addSPIDKeys(added)
         }
 
         if (removed.size > 0) {
-            this.removeStreams(removed)
+            this.removeSPIDKeys(removed)
         }
     }
 
-    private addStreams(keysToAdd: Set<StreamKey>): void {
-        logger.info('Add %d streams to storage config: %s', keysToAdd.size, Array.from(keysToAdd).join(','))
-        this.streamKeys = new Set([...this.streamKeys, ...keysToAdd])
+    private addSPIDKeys(keysToAdd: Set<Protocol.SPIDKey>): void {
+        logger.info('Add %d SPIDs to storage config: %s', keysToAdd.size, Array.from(keysToAdd).join(','))
+        this.spidKeys = new Set([...this.spidKeys, ...keysToAdd])
         this.listeners.forEach((listener) => {
-            keysToAdd.forEach((key: StreamKey) => listener.onStreamAdded(getStreamFromKey(key)))
+            keysToAdd.forEach((key: Protocol.SPIDKey) => listener.onSPIDAdded(Protocol.SPID.from(key)))
         })
     }
 
-    private removeStreams(keysToRemove: Set<StreamKey>): void {
-        logger.info('Remove %d streams from storage config: %s', keysToRemove.size, Array.from(keysToRemove).join(','))
-        this.streamKeys = new Set([...this.streamKeys].filter((x) => !keysToRemove.has(x)))
+    private removeSPIDKeys(keysToRemove: Set<Protocol.SPIDKey>): void {
+        logger.info('Remove %d SPIDs from storage config: %s', keysToRemove.size, Array.from(keysToRemove).join(','))
+        this.spidKeys = new Set([...this.spidKeys].filter((x) => !keysToRemove.has(x)))
         this.listeners.forEach((listener) => {
-            keysToRemove.forEach((key: StreamKey) => listener.onStreamRemoved(getStreamFromKey(key)))
+            keysToRemove.forEach((key: Protocol.SPIDKey) => listener.onSPIDRemoved(Protocol.SPID.from(key)))
         })
     }
 
-    private belongsToMeInCluster(key: StreamKey): boolean {
+    private belongsToMeInCluster(key: Protocol.SPIDKey): boolean {
         const hashedIndex = Protocol.keyToArrayIndex(this.clusterSize, key.toString())
         return hashedIndex === this.myIndexInCluster
     }
@@ -173,11 +159,11 @@ export class StorageConfig {
         const messageListener = (msg: Protocol.StreamMessage<AssignmentMessage>) => {
             if (msg.messageId.streamId === assignmentStreamId) {
                 const content = msg.getParsedContent() as any
-                const keys = new Set(getKeysFromStream(content.stream.id, content.stream.partitions))
+                const keys = new Set(getSPIDKeys(content.stream.id, content.stream.partitions))
                 if (content.event === 'STREAM_ADDED') {
-                    this.addStreams(keys)
+                    this.addSPIDKeys(keys)
                 } else if (content.event === 'STREAM_REMOVED') {
-                    this.removeStreams(keys)
+                    this.removeSPIDKeys(keys)
                 }
             }
         }
@@ -190,16 +176,16 @@ export class StorageConfig {
         if (content.storageNode && typeof content.storageNode === 'string' && content.storageNode.toLowerCase() === this.clusterId.toLowerCase()) {
             logger.trace('Received storage assignment message: %o', content)
             const keys = new Set(
-                getKeysFromStream(content.stream.id, content.stream.partitions)
-                    .filter ((key: StreamKey) => this.belongsToMeInCluster(key))
+                getSPIDKeys(content.stream.id, content.stream.partitions)
+                    .filter ((key: Protocol.SPIDKey) => this.belongsToMeInCluster(key))
             )
 
             logger.trace('Adding %d of %d partitions in stream %s to this instance', keys.size, content.stream.partitions, content.stream.id)
 
             if (content.event === 'STREAM_ADDED') {
-                this.addStreams(keys)
+                this.addSPIDKeys(keys)
             } else if (content.event === 'STREAM_REMOVED') {
-                this.removeStreams(keys)
+                this.removeSPIDKeys(keys)
             }
         } else if (!content.storageNode) {
             logger.error('Received storage assignment message with no storageNode field present: %o', content)

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch'
 import { Logger, Protocol } from 'streamr-network'
-import { SPID } from 'streamr-network/dist/streamr-protocol'
 import { SubscriptionManager } from '../../SubscriptionManager'
 
 const logger = new Logger(module)
@@ -91,7 +90,7 @@ export class StorageConfig {
     }
 
     getSPIDs(): Protocol.SPID[] {
-        return Array.from(this.spidKeys, (key) => SPID.from(key))
+        return Array.from(this.spidKeys, (key) => Protocol.SPID.from(key))
     }
 
     addChangeListener(listener: StorageConfigListener): void {

--- a/packages/broker/src/plugins/storage/StorageConfigEndpoints.ts
+++ b/packages/broker/src/plugins/storage/StorageConfigEndpoints.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, Router } from 'express'
+import { Protocol } from 'streamr-network'
 import { StorageConfig } from './StorageConfig'
 import { LEGACY_API_ROUTE_PREFIX } from '../../httpServer'
 
@@ -7,10 +8,7 @@ const createHandler = (storageConfig: StorageConfig) => {
         const { id, partition } = req.params
         const isValidPartition = !Number.isNaN(parseInt(partition))
         if (isValidPartition) {
-            const found = storageConfig.hasStream({
-                id,
-                partition: Number(partition)
-            })
+            const found = storageConfig.hasSPID(new Protocol.SPID(id, Number(partition)))
             if (found) {
                 res.status(200).send({})
             } else {

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -45,7 +45,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
         this.cassandra = await this.getCassandraStorage()
         this.storageConfig = await this.createStorageConfig()
         this.messageListener = (msg) => {
-            if (this.storageConfig!.hasSPID(Protocol.SPID.from(msg.messageId))) {
+            if (this.storageConfig!.hasSPID(msg.getSPID())) {
                 this.cassandra!.store(msg)
             }
         }

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -8,7 +8,6 @@ import { Plugin, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 import { Storage, startCassandraStorage } from './Storage'
 import { StorageConfig, AssignmentMessage } from './StorageConfig'
-import { StreamPart } from '../../types'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { Schema } from 'ajv'
 
@@ -46,20 +45,16 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
         this.cassandra = await this.getCassandraStorage()
         this.storageConfig = await this.createStorageConfig()
         this.messageListener = (msg) => {
-            const streamPart = {
-                id: msg.messageId.streamId,
-                partition: msg.messageId.streamPartition
-            }
-            if (this.storageConfig!.hasStream(streamPart)) {
+            if (this.storageConfig!.hasSPID(Protocol.SPID.from(msg.messageId))) {
                 this.cassandra!.store(msg)
             }
         }
-        this.storageConfig.getStreams().forEach((stream) => {
-            this.subscriptionManager.subscribe(stream.id, stream.partition)
+        this.storageConfig.getSPIDs().forEach((spid) => {
+            this.subscriptionManager.subscribe(spid.streamId, spid.streamPartition)
         })
         this.storageConfig.addChangeListener({
-            onStreamAdded: (stream: StreamPart) => this.subscriptionManager.subscribe(stream.id, stream.partition),
-            onStreamRemoved: (stream: StreamPart) => this.subscriptionManager.unsubscribe(stream.id, stream.partition)
+            onSPIDAdded: (spid: Protocol.SPID) => this.subscriptionManager.subscribe(spid.streamId, spid.streamPartition),
+            onSPIDRemoved: (spid: Protocol.SPID) => this.subscriptionManager.unsubscribe(spid.streamId, spid.streamPartition)
         })
         this.networkNode.addMessageListener(this.messageListener)
         const streamFetcher = new StreamFetcher(this.brokerConfig.streamrUrl)
@@ -99,8 +94,8 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
     async stop(): Promise<void> {
         this.storageConfig!.stopAssignmentEventListener(this.assignmentMessageListener!, this.brokerConfig.streamrAddress, this.subscriptionManager)
         this.networkNode.removeMessageListener(this.messageListener!)
-        this.storageConfig!.getStreams().forEach((stream) => {
-            this.subscriptionManager.unsubscribe(stream.id, stream.partition)
+        this.storageConfig!.getSPIDs().forEach((spid) => {
+            this.subscriptionManager.unsubscribe(spid.streamId, spid.streamPartition)
         })
         await Promise.all([
             this.cassandra!.close(),

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -1,8 +1,3 @@
-export interface StreamPart {
-    id: string
-    partition: number
-}
-
 export interface SslCertificateConfig {
     privateKeyFileName: string
     certFileName: string

--- a/packages/broker/src/types/global.d.ts
+++ b/packages/broker/src/types/global.d.ts
@@ -1,0 +1,1 @@
+import 'jest-extended'

--- a/packages/broker/test/integration/SubscriptionManager.test.ts
+++ b/packages/broker/test/integration/SubscriptionManager.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream } from 'streamr-client'
 import { startTracker, Tracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Broker } from '../broker'
-import { startBroker, fastPrivateKey, createClient, createMqttClient, createTestStream } from '../utils'
+import { startBroker, fastPrivateKey, createClient, createMqttClient, createTestStream, getSPIDKeys } from '../utils'
 
 const httpPort1 = 13381
 const httpPort2 = 13382
@@ -80,20 +80,20 @@ describe('SubscriptionManager', () => {
         await mqttClient1.subscribe(freshStream1.id)
         await mqttClient2.subscribe(freshStream2.id)
 
-        await waitForCondition(() => broker1.getStreams().length === 1)
-        await waitForCondition(() => broker2.getStreams().length === 1)
+        await waitForCondition(() => getSPIDKeys(broker1).length === 1)
+        await waitForCondition(() => getSPIDKeys(broker2).length === 1)
 
-        expect(broker1.getStreams()).toEqual([freshStream1.id + '::0'])
-        expect(broker2.getStreams()).toEqual([freshStream2.id + '::0'])
+        expect(getSPIDKeys(broker1)).toIncludeSameMembers([freshStream1.id + '#0'])
+        expect(getSPIDKeys(broker2)).toIncludeSameMembers([freshStream2.id + '#0'])
 
         await mqttClient1.subscribe(freshStream2.id)
         await mqttClient2.subscribe(freshStream1.id)
 
-        await waitForCondition(() => broker1.getStreams().length === 2)
-        await waitForCondition(() => broker2.getStreams().length === 2)
+        await waitForCondition(() => getSPIDKeys(broker1).length === 2)
+        await waitForCondition(() => getSPIDKeys(broker2).length === 2)
 
-        expect(broker1.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
+        expect(getSPIDKeys(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
+        expect(getSPIDKeys(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
 
         // client boots own node, so broker streams should not change
         await client1.subscribe(freshStream1, () => {})
@@ -102,23 +102,23 @@ describe('SubscriptionManager', () => {
 
         await wait(500) // give some time for client1 to subscribe.
 
-        expect(broker1.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
+        expect(getSPIDKeys(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
+        expect(getSPIDKeys(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
 
         await mqttClient1.unsubscribe(freshStream1.id)
 
-        await waitForCondition(() => broker1.getStreams().length === 1)
-        await waitForCondition(() => broker2.getStreams().length === 2)
+        await waitForCondition(() => getSPIDKeys(broker1).length === 1)
+        await waitForCondition(() => getSPIDKeys(broker2).length === 2)
 
-        expect(broker1.getStreams()).toEqual([freshStream2.id + '::0'])
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
+        expect(getSPIDKeys(broker1)).toIncludeSameMembers([freshStream2.id + '#0'])
+        expect(getSPIDKeys(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
 
         await mqttClient1.unsubscribe(freshStream2.id)
 
-        await waitForCondition(() => broker1.getStreams().length === 0)
-        await waitForCondition(() => broker2.getStreams().length === 2)
+        await waitForCondition(() => getSPIDKeys(broker1).length === 0)
+        await waitForCondition(() => getSPIDKeys(broker2).length === 2)
 
-        expect(broker1.getStreams()).toEqual([])
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0', freshStream2.id + '::0'].sort())
+        expect(getSPIDKeys(broker1)).toIncludeSameMembers([])
+        expect(getSPIDKeys(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'].sort())
     }, 10000)
 })

--- a/packages/broker/test/integration/plugins/legacyMqtt/mqtt-error-handling.test.ts
+++ b/packages/broker/test/integration/plugins/legacyMqtt/mqtt-error-handling.test.ts
@@ -1,8 +1,8 @@
 import { AsyncMqttClient } from 'async-mqtt'
 import { Socket } from 'net'
 import { startTracker, Tracker } from 'streamr-network'
-import {waitForEvent} from '../../../../../test-utils/dist/utils'
-import { Broker } from '../../../broker'
+import { waitForEvent } from 'streamr-test-utils'
+import { Broker } from '../../../../src/broker'
 import { startBroker, createMqttClient } from '../../../utils'
 
 const trackerPort = 12411

--- a/packages/broker/test/integration/plugins/legacyMqtt/mqtt.test.ts
+++ b/packages/broker/test/integration/plugins/legacyMqtt/mqtt.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream } from 'streamr-client'
 import { startTracker, Tracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Broker } from '../../../broker'
-import { startBroker, fastPrivateKey, createClient, createMqttClient, createTestStream } from '../../../utils'
+import { startBroker, fastPrivateKey, createClient, createMqttClient, createTestStream, getSPIDKeys } from '../../../utils'
 
 const httpPort1 = 12381
 const httpPort2 = 12382
@@ -369,14 +369,14 @@ describe('mqtt: end-to-end', () => {
         await waitForCondition(() => broker2.getNeighbors().length === 1)
 
         // for mqtt partition is always zero
-        expect(broker1.getStreams()).toEqual([freshStream1.id + '::0'])
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0'])
+        expect(getSPIDKeys(broker1)).toEqual([freshStream1.id + '#0'])
+        expect(getSPIDKeys(broker2)).toEqual([freshStream1.id + '#0'])
         await mqttClient1.unsubscribe(freshStream1.id)
 
-        await waitForCondition(() => broker1.getStreams().length === 0)
-        await waitForCondition(() => broker2.getStreams().length === 1)
+        await waitForCondition(() => getSPIDKeys(broker1).length === 0)
+        await waitForCondition(() => getSPIDKeys(broker2).length === 1)
 
-        expect(broker1.getStreams()).toEqual([])
-        expect(broker2.getStreams()).toEqual([freshStream1.id + '::0'])
+        expect(getSPIDKeys(broker1)).toEqual([])
+        expect(getSPIDKeys(broker2)).toEqual([freshStream1.id + '#0'])
     }, 10000)
 })

--- a/packages/broker/test/integration/plugins/storage/MockStorageConfig.ts
+++ b/packages/broker/test/integration/plugins/storage/MockStorageConfig.ts
@@ -1,12 +1,12 @@
-import { StreamPart } from '../../../../src/types'
+import { Protocol } from 'streamr-network'
 
-export const createMockStorageConfig = (streams: StreamPart[]): any => {
+export const createMockStorageConfig = (spids: Protocol.SPID[]): any => {
     return {
-        hasStream: (stream: StreamPart) => {
-            return streams.some((s) => (s.id === stream.id) && (s.partition === stream.partition))
+        hasSPID: (spid: Protocol.SPID) => {
+            return spids.some((s) => (s.streamId === spid.streamId) && (s.streamPartition === spid.streamPartition))
         },
-        getStreams: () => {
-            return streams
+        getSPIDs: () => {
+            return spids
         },
         addChangeListener: () => {},
         startAssignmentEventListener: jest.fn(),

--- a/packages/broker/test/integration/plugins/storage/StoragePlugin.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StoragePlugin.test.ts
@@ -1,16 +1,12 @@
-import { MetricsContext } from 'streamr-network'
+import { MetricsContext, Protocol } from 'streamr-network'
 import { StoragePlugin } from '../../../../src/plugins/storage/StoragePlugin'
 import { StorageConfig } from '../../../../src/plugins/storage/StorageConfig'
-import { StreamPart } from '../../../../src/types'
 import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
 import { createMockStorageConfig } from './MockStorageConfig'
 import { StorageNodeRegistry } from "../../../../src/StorageNodeRegistry"
 import { Wallet } from 'ethers'
 
-const STREAM_PARTS: StreamPart[] = [
-    { id: 'foo', partition: 0 },
-    { id: 'bar', partition: 0 }
-]
+const SPIDS: Protocol.SPID[] = [new Protocol.SPID('foo', 0), new Protocol.SPID('bar', 0)]
 
 const createMockPlugin = (networkNode: any, subscriptionManager: any) => {
     const wallet = Wallet.createRandom()
@@ -64,7 +60,7 @@ describe('StoragePlugin', () => {
             subscribe: jest.fn(),
             unsubscribe: jest.fn()
         }
-        storageConfig = createMockStorageConfig(STREAM_PARTS)
+        storageConfig = createMockStorageConfig(SPIDS)
         storageConfigFactory = jest.spyOn(StorageConfig, 'createInstance')
         storageConfigFactory.mockResolvedValue(storageConfig)
     })
@@ -76,13 +72,13 @@ describe('StoragePlugin', () => {
     test('happy path: start and stop', async () => {
         const plugin = createMockPlugin(networkNode, subscriptionManager)
         await plugin.start()
-        expect(subscriptionManager.subscribe).toBeCalledTimes(STREAM_PARTS.length)
+        expect(subscriptionManager.subscribe).toBeCalledTimes(SPIDS.length)
         expect(networkNode.addMessageListener).toBeCalledTimes(1)
         expect(storageConfig.startAssignmentEventListener).toBeCalledTimes(1)
         // @ts-expect-error private field
         const cassandraClose = jest.spyOn(plugin.cassandra!, 'close')
         await plugin.stop()
-        expect(subscriptionManager.unsubscribe).toBeCalledTimes(STREAM_PARTS.length)
+        expect(subscriptionManager.unsubscribe).toBeCalledTimes(SPIDS.length)
         expect(networkNode.removeMessageListener).toBeCalledTimes(1)
         expect(storageConfig.stopAssignmentEventListener).toBeCalledTimes(1)
         expect(storageConfig.cleanup).toBeCalledTimes(1)

--- a/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
@@ -1,11 +1,11 @@
 import { Server } from 'http'
 import { once } from 'events'
 import { Logger, startTracker, Tracker } from 'streamr-network'
+import { waitForCondition } from 'streamr-test-utils'
 import express, { Request, Response} from 'express'
 import { Broker } from '../../../../src/broker'
 import { createClient, createTestStream, fastPrivateKey, startBroker } from '../../../utils'
 import { Stream, StreamOperation, StreamrClient } from 'streamr-client'
-import { waitForCondition } from '../../../../../test-utils/dist/utils'
 import { Wallet } from 'ethers'
 import { version as CURRENT_VERSION } from '../../../../package.json'
 

--- a/packages/broker/test/unit/plugins/legacyWebsocket/Connection.test.ts
+++ b/packages/broker/test/unit/plugins/legacyWebsocket/Connection.test.ts
@@ -121,9 +121,9 @@ describe('Connection', () => {
                 connection.addStream(new Stream('stream2', 0, ''))
                 connection.addStream(new Stream('stream3', 0, ''))
                 expect(connection.getStreamsAsString()).toEqual([
-                    'stream1::0',
-                    'stream2::0',
-                    'stream3::0',
+                    'stream1#0',
+                    'stream2#0',
+                    'stream3#0',
                 ])
             })
         })

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle, object-curly-newline */
 import { StorageConfig, StorageConfigListener } from '../../../../src/plugins/storage/StorageConfig'
 import nock from 'nock'
+import { SPID } from 'streamr-network/dist/streamr-protocol'
 
 describe('StorageConfig', () => {
 
@@ -18,43 +19,43 @@ describe('StorageConfig', () => {
         beforeEach(() => {
             config = new StorageConfig('nodeId', 1, 0, 'http://api-url.com/path')
             // @ts-expect-error private
-            config.setStreams(new Set(['existing1::0', 'existing2::0', 'existing2::1', 'existing3::0']))
+            config.setSPIDKeys(new Set(['existing1#0', 'existing2#0', 'existing2#1', 'existing3#0']))
             listener = {
-                onStreamAdded: jest.fn(),
-                onStreamRemoved: jest.fn()
+                onSPIDAdded: jest.fn(),
+                onSPIDRemoved: jest.fn()
             }
             config.addChangeListener(listener)
         })
 
         it('setStreams', () => {
             // @ts-expect-error private
-            config.setStreams(new Set(['existing2::0', 'existing3::0', 'new1::0', 'new2::0']))
-            expect(listener.onStreamAdded).toBeCalledTimes(2)
-            expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'new1', partition: 0 })
-            expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'new2', partition: 0 })
-            expect(listener.onStreamRemoved).toBeCalledTimes(2)
-            expect(listener.onStreamRemoved).toHaveBeenCalledWith({ id: 'existing1', partition: 0 })
-            expect(listener.onStreamRemoved).toHaveBeenCalledWith({ id: 'existing2', partition: 1 })
-            expect(config.hasStream({ id: 'new1', partition: 0 })).toBeTruthy()
-            expect(config.hasStream({ id: 'existing1', partition: 0 })).toBeFalsy()
-            expect(config.hasStream({ id: 'other', partition: 0 })).toBeFalsy()
+            config.setSPIDKeys(new Set(['existing2#0', 'existing3#0', 'new1#0', 'new2#0']))
+            expect(listener.onSPIDAdded).toBeCalledTimes(2)
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('new1', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('new2', 0))
+            expect(listener.onSPIDRemoved).toBeCalledTimes(2)
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing1', 0))
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 1))
+            expect(config.hasSPID(new SPID('new1', 0))).toBeTruthy()
+            expect(config.hasSPID(new SPID('existing1', 0))).toBeFalsy()
+            expect(config.hasSPID(new SPID('other', 0))).toBeFalsy()
         })
 
         it('addStream', () => {
             // @ts-expect-error private
-            config.addStreams(new Set(['loremipsum::0', 'foo::0', 'bar::0']))
-            expect(listener.onStreamAdded).toBeCalledTimes(3)
-            expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'loremipsum', partition: 0 })
-            expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'foo', partition: 0 })
-            expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'bar', partition: 0 })
+            config.addSPIDKeys(new Set(['loremipsum#0', 'foo#0', 'bar#0']))
+            expect(listener.onSPIDAdded).toBeCalledTimes(3)
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('loremipsum', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('foo', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('bar', 0))
         })
 
         it('removeStreams', () => {
             // @ts-expect-error private
-            config.removeStreams(new Set(['existing2::0', 'existing2::1']))
-            expect(listener.onStreamRemoved).toBeCalledTimes(2)
-            expect(listener.onStreamRemoved).toHaveBeenCalledWith({ id: 'existing2', partition: 0 })
-            expect(listener.onStreamRemoved).toHaveBeenCalledWith({ id: 'existing2', partition: 1 })
+            config.removeSPIDKeys(new Set(['existing2#0', 'existing2#1']))
+            expect(listener.onSPIDRemoved).toBeCalledTimes(2)
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 0))
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 1))
         })
 
         it('refresh', async () => {
@@ -72,9 +73,9 @@ describe('StorageConfig', () => {
                 ])
 
             await config.refresh()
-            expect(config.hasStream({ id: 'foo', partition: 0 })).toBeTruthy()
-            expect(config.hasStream({ id: 'foo', partition: 1 })).toBeTruthy()
-            expect(config.hasStream({ id: 'bar', partition: 0 })).toBeTruthy()
+            expect(config.hasSPID(new SPID('foo', 0))).toBeTruthy()
+            expect(config.hasSPID(new SPID('foo', 1))).toBeTruthy()
+            expect(config.hasSPID(new SPID('bar', 0))).toBeTruthy()
         })
 
         it('onAssignmentEvent', () => {
@@ -86,8 +87,8 @@ describe('StorageConfig', () => {
                 }, 
                 event: 'STREAM_ADDED'
             })
-            expect(config.hasStream({ id: 'foo', partition: 0 })).toBeTruthy()
-            expect(config.hasStream({ id: 'foo', partition: 1 })).toBeTruthy()
+            expect(config.hasSPID(new SPID('foo', 0))).toBeTruthy()
+            expect(config.hasSPID(new SPID('foo', 1))).toBeTruthy()
         })
     })
 
@@ -118,9 +119,12 @@ describe('StorageConfig', () => {
                 ]))
 
             await Promise.all(configs.map((config) => config.refresh()))
-            expect(configs[0].streamKeys.size).toBe(69)
-            expect(configs[1].streamKeys.size).toBe(57)
-            expect(configs[2].streamKeys.size).toBe(74)
+            // @ts-expect-error private field
+            expect(configs[0].spidKeys.size).toBe(61)
+            // @ts-expect-error private field
+            expect(configs[1].spidKeys.size).toBe(67)
+            // @ts-expect-error private field
+            expect(configs[2].spidKeys.size).toBe(72)
         })
 
         it('onAssignmentEvent', () => {
@@ -132,9 +136,12 @@ describe('StorageConfig', () => {
                 }, 
                 event: 'STREAM_ADDED'
             }))
-            expect(configs[0].streamKeys.size).toBe(38)
-            expect(configs[1].streamKeys.size).toBe(30)
-            expect(configs[2].streamKeys.size).toBe(32)
+            // @ts-expect-error private field
+            expect(configs[0].spidKeys.size).toBe(23)
+            // @ts-expect-error private field
+            expect(configs[1].spidKeys.size).toBe(42)
+            // @ts-expect-error private field
+            expect(configs[2].spidKeys.size).toBe(35)
         })
     })
 })

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle, object-curly-newline */
 import { StorageConfig, StorageConfigListener } from '../../../../src/plugins/storage/StorageConfig'
 import nock from 'nock'
-import { SPID } from 'streamr-network/dist/streamr-protocol'
+import { Protocol } from 'streamr-network'
 
 describe('StorageConfig', () => {
 
@@ -31,31 +31,31 @@ describe('StorageConfig', () => {
             // @ts-expect-error private
             config.setSPIDKeys(new Set(['existing2#0', 'existing3#0', 'new1#0', 'new2#0']))
             expect(listener.onSPIDAdded).toBeCalledTimes(2)
-            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('new1', 0))
-            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('new2', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new Protocol.SPID('new1', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new Protocol.SPID('new2', 0))
             expect(listener.onSPIDRemoved).toBeCalledTimes(2)
-            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing1', 0))
-            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 1))
-            expect(config.hasSPID(new SPID('new1', 0))).toBeTruthy()
-            expect(config.hasSPID(new SPID('existing1', 0))).toBeFalsy()
-            expect(config.hasSPID(new SPID('other', 0))).toBeFalsy()
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new Protocol.SPID('existing1', 0))
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new Protocol.SPID('existing2', 1))
+            expect(config.hasSPID(new Protocol.SPID('new1', 0))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('existing1', 0))).toBeFalsy()
+            expect(config.hasSPID(new Protocol.SPID('other', 0))).toBeFalsy()
         })
 
         it('addStream', () => {
             // @ts-expect-error private
             config.addSPIDKeys(new Set(['loremipsum#0', 'foo#0', 'bar#0']))
             expect(listener.onSPIDAdded).toBeCalledTimes(3)
-            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('loremipsum', 0))
-            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('foo', 0))
-            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new SPID('bar', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new Protocol.SPID('loremipsum', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new Protocol.SPID('foo', 0))
+            expect(listener.onSPIDAdded).toHaveBeenCalledWith(new Protocol.SPID('bar', 0))
         })
 
         it('removeStreams', () => {
             // @ts-expect-error private
             config.removeSPIDKeys(new Set(['existing2#0', 'existing2#1']))
             expect(listener.onSPIDRemoved).toBeCalledTimes(2)
-            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 0))
-            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new SPID('existing2', 1))
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new Protocol.SPID('existing2', 0))
+            expect(listener.onSPIDRemoved).toHaveBeenCalledWith(new Protocol.SPID('existing2', 1))
         })
 
         it('refresh', async () => {
@@ -73,9 +73,9 @@ describe('StorageConfig', () => {
                 ])
 
             await config.refresh()
-            expect(config.hasSPID(new SPID('foo', 0))).toBeTruthy()
-            expect(config.hasSPID(new SPID('foo', 1))).toBeTruthy()
-            expect(config.hasSPID(new SPID('bar', 0))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('foo', 0))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('foo', 1))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('bar', 0))).toBeTruthy()
         })
 
         it('onAssignmentEvent', () => {
@@ -87,8 +87,8 @@ describe('StorageConfig', () => {
                 }, 
                 event: 'STREAM_ADDED'
             })
-            expect(config.hasSPID(new SPID('foo', 0))).toBeTruthy()
-            expect(config.hasSPID(new SPID('foo', 1))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('foo', 0))).toBeTruthy()
+            expect(config.hasSPID(new Protocol.SPID('foo', 1))).toBeTruthy()
         })
     })
 

--- a/packages/broker/test/unit/plugins/storage/StorageConfigEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfigEndpoints.test.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { Protocol } from 'streamr-network'
 import request from 'supertest'
 import { router } from '../../../../src/plugins/storage/StorageConfigEndpoints'
 import { createMockStorageConfig } from '../../../integration/plugins/storage/MockStorageConfig'
@@ -8,10 +9,7 @@ const createRequest = (streamId: string, partition: number, app: express.Applica
 }
 
 describe('StorageConfigEndpoints', () => {
-    const storageConfig = createMockStorageConfig([{
-        id: 'existing',
-        partition: 123,
-    }])
+    const storageConfig = createMockStorageConfig([new Protocol.SPID('existing', 123)])
 
     it('stream in storage config', async () => {
         const app = express()

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream, StreamProperties, StreamrClientOptions } from 's
 import mqtt from 'async-mqtt'
 import fetch from 'node-fetch'
 import { Wallet } from 'ethers'
-import { Tracker } from 'streamr-network'
+import { Tracker, Protocol } from 'streamr-network'
 import { waitForCondition } from 'streamr-test-utils'
 import { Broker, createBroker } from '../src/broker'
 import { StorageConfig } from '../src/plugins/storage/StorageConfig'
@@ -255,4 +255,8 @@ export class Queue<T> {
         await waitForCondition(() => this.items.length > 0, timeout)
         return this.items.shift()!
     }
+}
+
+export const getSPIDKeys = (broker: Broker): Protocol.SPIDKey[] => {
+    return Array.from(broker.getSPIDs(), (spid) => spid.toKey())
 }

--- a/packages/network/src/helpers/transformIterable.ts
+++ b/packages/network/src/helpers/transformIterable.ts
@@ -1,0 +1,5 @@
+export const transformIterable = function *<F,T>(from: Iterable<F>, tranform: (f: F) => T): Iterable<T> {
+    for (const f of from) {
+        yield tranform(f)
+    }
+}

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -1,43 +1,5 @@
-import { SmartContractRecord, TrackerLayer } from 'streamr-client-protocol'
+import { SmartContractRecord, SPIDKey, TrackerLayer } from 'streamr-client-protocol'
 import { NodeId } from './logic/node/Node'
-
-/**
- * Uniquely identifies a stream
- */
-export class StreamIdAndPartition {
-    public readonly id: string
-    public readonly partition: number
-
-    constructor(id: string, partition: number) {
-        if (typeof id !== 'string') {
-            throw new Error(`invalid id: ${id}`)
-        }
-        if (!Number.isInteger(partition)) {
-            throw new Error(`invalid partition: ${partition}`)
-        }
-        this.id = id
-        this.partition = partition
-    }
-
-    key(): StreamKey {
-        return this.toString()
-    }
-
-    toString(): string {
-        return `${this.id}::${this.partition}`
-    }
-
-    static fromMessage(message: { streamId: string, streamPartition: number }): StreamIdAndPartition {
-        return new StreamIdAndPartition(message.streamId, message.streamPartition)
-    }
-
-    static fromKey(key: string): StreamIdAndPartition {
-        const [id, partition] = key.split('::')
-        return new StreamIdAndPartition(id, Number.parseInt(partition, 10))
-    }
-}
-
-export type StreamKey = string // Represents format streamId::streamPartition
 
 export interface Rtts {
     [key: string]: number
@@ -51,7 +13,7 @@ export interface Location {
 }
 
 export interface StreamStatus {
-    streamKey: StreamKey
+    spidKey: SPIDKey
     neighbors: NodeId[]
     counter: number // TODO this field could be a field of "Status" interface, not this interface?
 }

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -1,4 +1,4 @@
-import { SmartContractRecord, SPIDKey, TrackerLayer } from 'streamr-client-protocol'
+import { SmartContractRecord, TrackerLayer } from 'streamr-client-protocol'
 import { NodeId } from './logic/node/Node'
 
 export interface Rtts {
@@ -13,7 +13,8 @@ export interface Location {
 }
 
 export interface StreamStatus {
-    spidKey: SPIDKey
+    id: string
+    partition: number,
     neighbors: NodeId[]
     counter: number // TODO this field could be a field of "Status" interface, not this interface?
 }

--- a/packages/network/src/logic/node/InstructionRetryManager.ts
+++ b/packages/network/src/logic/node/InstructionRetryManager.ts
@@ -1,4 +1,4 @@
-import { SPID, SPIDKey } from 'streamr-client-protocol'
+import { SPIDKey } from 'streamr-client-protocol'
 import { TrackerLayer } from "streamr-client-protocol"
 import { Logger } from "../../helpers/Logger"
 import { TrackerId } from '../tracker/Tracker'
@@ -33,7 +33,7 @@ export class InstructionRetryManager {
         if (this.stopped) {
             return
         }
-        const spidKey = SPID.from(instructionMessage).toKey()
+        const spidKey = instructionMessage.getSPID().toKey()
         if (this.instructionRetryIntervals[spidKey]) {
             clearTimeout(this.instructionRetryIntervals[spidKey].interval)
         }
@@ -49,7 +49,7 @@ export class InstructionRetryManager {
         if (this.stopped) {
             return
         }
-        const spidKey = SPID.from(instructionMessage).toKey()
+        const spidKey = instructionMessage.getSPID().toKey()
         try {
             // First and every nth instruction retries will always send status messages to tracker
             await this.handleFn(instructionMessage, trackerId, this.instructionRetryIntervals[spidKey].counter !== 0)

--- a/packages/network/src/logic/node/InstructionThrottler.ts
+++ b/packages/network/src/logic/node/InstructionThrottler.ts
@@ -1,10 +1,10 @@
+import { SPID, SPIDKey } from 'streamr-client-protocol'
 import { cancelable, CancelablePromiseType } from 'cancelable-promise'
-import { StreamIdAndPartition, StreamKey } from '../../identifiers'
 import { TrackerLayer } from 'streamr-client-protocol'
 import { Logger } from "../../helpers/Logger"
 import { TrackerId } from '../tracker/Tracker'
 
-type Queue = Record<StreamKey, {
+type Queue = Record<SPIDKey, {
     instructionMessage: TrackerLayer.InstructionMessage
     trackerId: TrackerId
 }>
@@ -15,14 +15,14 @@ type HandleFn = (instructionMessage: TrackerLayer.InstructionMessage, trackerId:
  * InstructionThrottler makes sure that
  *  1. no more than one instruction is handled at a time
  *  2. any new instructions arriving while an instruction is being handled are queued in a
- *     way where only the most latest instruction per streamKey is kept in queue.
+ *     way where only the most latest instruction per spidKey is kept in queue.
  */
 export class InstructionThrottler {
     private readonly logger: Logger
     private readonly handleFn: HandleFn
     private queue: Queue = {}
-    private instructionCounter: Record<StreamKey,number> = {} // streamKey => counter
-    private ongoingPromises: Record<StreamKey, {
+    private instructionCounter: Record<SPIDKey,number> = {} // spidKey => counter
+    private ongoingPromises: Record<SPIDKey, {
         promise: CancelablePromiseType<void> | null
         handling: boolean
     }>
@@ -39,38 +39,38 @@ export class InstructionThrottler {
         if (this.stopped) {
             return
         }
-        const streamKey = StreamIdAndPartition.fromMessage(instructionMessage).key()
-        if (!this.instructionCounter[streamKey] || this.instructionCounter[streamKey] <= instructionMessage.counter) {
-            this.instructionCounter[streamKey] = instructionMessage.counter
-            this.queue[StreamIdAndPartition.fromMessage(instructionMessage).key()] = {
+        const spidKey = SPID.from(instructionMessage).toKey()
+        if (!this.instructionCounter[spidKey] || this.instructionCounter[spidKey] <= instructionMessage.counter) {
+            this.instructionCounter[spidKey] = instructionMessage.counter
+            this.queue[spidKey] = {
                 instructionMessage,
                 trackerId
             }
 
-            if (!this.ongoingPromises[streamKey]) {
-                this.ongoingPromises[streamKey] = {
+            if (!this.ongoingPromises[spidKey]) {
+                this.ongoingPromises[spidKey] = {
                     promise: null,
                     handling: false
                 }
             }
-            if (!this.ongoingPromises[streamKey].handling) {
-                this.invokeHandleFnWithLock(streamKey).catch((err) => {
+            if (!this.ongoingPromises[spidKey].handling) {
+                this.invokeHandleFnWithLock(spidKey).catch((err) => {
                     this.logger.warn("error handling instruction, reason: %s", err)
                 })
             }
         }
     }
 
-    removeStream(streamKey: StreamKey): void {
+    removeStream(spidKey: SPIDKey): void {
         if (this.stopped) {
             return
         }
-        delete this.queue[streamKey]
-        delete this.instructionCounter[streamKey]
-        if (this.ongoingPromises[streamKey]) {
-            this.ongoingPromises[streamKey].promise!.cancel()
+        delete this.queue[spidKey]
+        delete this.instructionCounter[spidKey]
+        if (this.ongoingPromises[spidKey]) {
+            this.ongoingPromises[spidKey].promise!.cancel()
         }
-        delete this.ongoingPromises[streamKey]
+        delete this.ongoingPromises[spidKey]
     }
 
     isIdle(): boolean {
@@ -80,38 +80,38 @@ export class InstructionThrottler {
     stop(): void {
         this.queue = {}
         this.instructionCounter = {}
-        Object.keys(this.ongoingPromises).forEach((streamKey) => {
-            if (this.ongoingPromises[streamKey]) {
-                this.ongoingPromises[streamKey].promise!.cancel()
+        Object.keys(this.ongoingPromises).forEach((spidKey) => {
+            if (this.ongoingPromises[spidKey]) {
+                this.ongoingPromises[spidKey].promise!.cancel()
             }
-            delete this.ongoingPromises[streamKey]
+            delete this.ongoingPromises[spidKey]
         })
         this.ongoingPromises = {}
         this.stopped = true
     }
 
-    private async invokeHandleFnWithLock(streamKey: StreamKey): Promise<void> {
+    private async invokeHandleFnWithLock(spidKey: SPIDKey): Promise<void> {
         if (this.stopped) {
             return
         }
-        if (!this.queue[streamKey]) {
-            if (this.ongoingPromises[streamKey]) {
-                this.ongoingPromises[streamKey].handling = false
+        if (!this.queue[spidKey]) {
+            if (this.ongoingPromises[spidKey]) {
+                this.ongoingPromises[spidKey].handling = false
             }
             return
         }
-        this.ongoingPromises[streamKey].handling = true
+        this.ongoingPromises[spidKey].handling = true
 
-        const { instructionMessage, trackerId } = this.queue[streamKey]
-        delete this.queue[streamKey]
+        const { instructionMessage, trackerId } = this.queue[spidKey]
+        delete this.queue[spidKey]
 
         try {
-            this.ongoingPromises[streamKey].promise = cancelable(this.handleFn(instructionMessage, trackerId))
-            await this.ongoingPromises[streamKey].promise
+            this.ongoingPromises[spidKey].promise = cancelable(this.handleFn(instructionMessage, trackerId))
+            await this.ongoingPromises[spidKey].promise
         } catch (err) {
             this.logger.warn('handling InstructionMessage threw, error %j', err)
         } finally {
-            this.invokeHandleFnWithLock(streamKey)
+            this.invokeHandleFnWithLock(spidKey)
         }
     }
 }

--- a/packages/network/src/logic/node/InstructionThrottler.ts
+++ b/packages/network/src/logic/node/InstructionThrottler.ts
@@ -1,4 +1,4 @@
-import { SPID, SPIDKey } from 'streamr-client-protocol'
+import { SPIDKey } from 'streamr-client-protocol'
 import { cancelable, CancelablePromiseType } from 'cancelable-promise'
 import { TrackerLayer } from 'streamr-client-protocol'
 import { Logger } from "../../helpers/Logger"
@@ -39,7 +39,7 @@ export class InstructionThrottler {
         if (this.stopped) {
             return
         }
-        const spidKey = SPID.from(instructionMessage).toKey()
+        const spidKey = instructionMessage.getSPID().toKey()
         if (!this.instructionCounter[spidKey] || this.instructionCounter[spidKey] <= instructionMessage.counter) {
             this.instructionCounter[spidKey] = instructionMessage.counter
             this.queue[spidKey] = {

--- a/packages/network/src/logic/node/NetworkNode.ts
+++ b/packages/network/src/logic/node/NetworkNode.ts
@@ -1,5 +1,5 @@
+import { SPID } from 'streamr-client-protocol'
 import { Node, Event as NodeEvent, NodeOptions, NodeId } from './Node'
-import { StreamIdAndPartition } from '../../identifiers'
 import { StreamMessage } from 'streamr-client-protocol'
 
 /*
@@ -30,15 +30,15 @@ export class NetworkNode extends Node {
     }
 
     subscribe(streamId: string, streamPartition: number): void {
-        this.subscribeToStreamIfHaveNotYet(new StreamIdAndPartition(streamId, streamPartition))
+        this.subscribeToStreamIfHaveNotYet(new SPID(streamId, streamPartition))
     }
 
     unsubscribe(streamId: string, streamPartition: number): void {
-        this.unsubscribeFromStream(new StreamIdAndPartition(streamId, streamPartition))
+        this.unsubscribeFromStream(new SPID(streamId, streamPartition))
     }
 
     getNeighborsForStream(streamId: string, streamPartition: number): ReadonlyArray<NodeId> {
-        return this.streams.getNeighborsForStream(new StreamIdAndPartition(streamId, streamPartition))
+        return this.streams.getNeighborsForStream(new SPID(streamId, streamPartition))
     }
 
     getRtt(nodeId: NodeId): number|undefined {

--- a/packages/network/src/logic/node/Node.ts
+++ b/packages/network/src/logic/node/Node.ts
@@ -330,8 +330,8 @@ export class Node extends EventEmitter {
         }, interval)
     }
 
-    getStreams(): ReadonlyArray<string> {
-        return this.streams.getStreamsAsKeys()
+    getSPIDs(): Iterable<SPID> {
+        return this.streams.getSPIDs()
     }
 
     getNeighbors(): ReadonlyArray<NodeId> {

--- a/packages/network/src/logic/node/Node.ts
+++ b/packages/network/src/logic/node/Node.ts
@@ -1,8 +1,7 @@
 import { EventEmitter } from 'events'
-import { MessageLayer, StreamMessage } from 'streamr-client-protocol'
+import { MessageLayer, SPID, StreamMessage } from 'streamr-client-protocol'
 import { NodeToNode, Event as NodeToNodeEvent } from '../../protocol/NodeToNode'
 import { NodeToTracker } from '../../protocol/NodeToTracker'
-import { StreamIdAndPartition } from '../../identifiers'
 import { Metrics, MetricsContext } from '../../helpers/MetricsContext'
 import { promiseTimeout } from '../../helpers/PromiseTools'
 import { StreamManager } from './StreamManager'
@@ -46,8 +45,8 @@ export interface Node {
     on(event: Event.NODE_DISCONNECTED, listener: (nodeId: NodeId) => void): this
     on<T>(event: Event.MESSAGE_RECEIVED, listener: (msg: MessageLayer.StreamMessage<T>, nodeId: NodeId) => void): this
     on<T>(event: Event.UNSEEN_MESSAGE_RECEIVED, listener: (msg: MessageLayer.StreamMessage<T>, nodeId: NodeId) => void): this
-    on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
-    on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
+    on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, spid: SPID) => void): this
+    on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, spid: SPID) => void): this
 }
 
 export class Node extends EventEmitter {
@@ -177,29 +176,29 @@ export class Node extends EventEmitter {
         this.connectionCleanUpInterval = this.startConnectionCleanUpInterval(2 * 60 * 1000)
     }
 
-    subscribeToStreamIfHaveNotYet(streamId: StreamIdAndPartition, sendStatus = true): void {
-        if (!this.streams.isSetUp(streamId)) {
-            logger.trace('add %s to streams', streamId)
-            this.streams.setUpStream(streamId)
-            this.trackerManager.onNewStream(streamId) // TODO: perhaps we should react based on event from StreamManager?
+    subscribeToStreamIfHaveNotYet(spid: SPID, sendStatus = true): void {
+        if (!this.streams.isSetUp(spid)) {
+            logger.trace('add %s to streams', spid)
+            this.streams.setUpStream(spid)
+            this.trackerManager.onNewStream(spid) // TODO: perhaps we should react based on event from StreamManager?
             if (sendStatus) {
-                this.trackerManager.sendStreamStatus(streamId)
+                this.trackerManager.sendStreamStatus(spid)
             }
         }
     }
 
-    unsubscribeFromStream(streamId: StreamIdAndPartition, sendStatus = true): void {
-        logger.trace('remove %s from streams', streamId)
-        this.streams.removeStream(streamId)
-        this.trackerManager.onUnsubscribeFromStream(streamId)
+    unsubscribeFromStream(spid: SPID, sendStatus = true): void {
+        logger.trace('remove %s from streams', spid)
+        this.streams.removeStream(spid)
+        this.trackerManager.onUnsubscribeFromStream(spid)
         if (sendStatus) {
-            this.trackerManager.sendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(spid)
         }
     }
 
     subscribeToStreamsOnNode(
         nodeIds: NodeId[],
-        streamId: StreamIdAndPartition,
+        spid: SPID,
         trackerId: TrackerId,
         reattempt: boolean
     ): Promise<PromiseSettledResult<NodeId>[]> {
@@ -208,7 +207,7 @@ export class Node extends EventEmitter {
                 this.nodeToNode.connectToNode(nodeId, trackerId, !reattempt))
 
             this.clearDisconnectionTimer(nodeId)
-            this.subscribeToStreamOnNode(nodeId, streamId, false)
+            this.subscribeToStreamOnNode(nodeId, spid, false)
             return nodeId
         })
         return Promise.allSettled(subscribePromises)
@@ -216,14 +215,14 @@ export class Node extends EventEmitter {
 
     onDataReceived(streamMessage: MessageLayer.StreamMessage, source: NodeId | null = null): void | never {
         this.metrics.record('onDataReceived', 1)
-        const streamIdAndPartition = new StreamIdAndPartition(
+        const spid = new SPID(
             streamMessage.getStreamId(),
             streamMessage.getStreamPartition()
         )
 
         this.emit(Event.MESSAGE_RECEIVED, streamMessage, source)
 
-        this.subscribeToStreamIfHaveNotYet(streamIdAndPartition)
+        this.subscribeToStreamIfHaveNotYet(spid)
 
         // Check duplicate
         let isUnseen
@@ -267,13 +266,13 @@ export class Node extends EventEmitter {
         return this.trackerManager.stop()
     }
 
-    private subscribeToStreamOnNode(node: NodeId, streamId: StreamIdAndPartition, sendStatus = true): NodeId {
-        this.streams.addNeighbor(streamId, node)
-        this.propagation.onNeighborJoined(node, streamId)
+    private subscribeToStreamOnNode(node: NodeId, spid: SPID, sendStatus = true): NodeId {
+        this.streams.addNeighbor(spid, node)
+        this.propagation.onNeighborJoined(node, spid)
         if (sendStatus) {
-            this.trackerManager.sendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(spid)
         }
-        this.emit(Event.NODE_SUBSCRIBED, node, streamId)
+        this.emit(Event.NODE_SUBSCRIBED, node, spid)
         return node
     }
 
@@ -281,10 +280,10 @@ export class Node extends EventEmitter {
         return this.streams.isNodePresent(nodeId)
     }
 
-    private unsubscribeFromStreamOnNode(node: NodeId, streamId: StreamIdAndPartition, sendStatus = true): void {
-        this.streams.removeNodeFromStream(streamId, node)
-        logger.trace('node %s unsubscribed from stream %s', node, streamId)
-        this.emit(Event.NODE_UNSUBSCRIBED, node, streamId)
+    private unsubscribeFromStreamOnNode(node: NodeId, spid: SPID, sendStatus = true): void {
+        this.streams.removeNodeFromStream(spid, node)
+        logger.trace('node %s unsubscribed from stream %s', node, spid)
+        this.emit(Event.NODE_UNSUBSCRIBED, node, spid)
 
         if (!this.streams.isNodePresent(node)) {
             this.clearDisconnectionTimer(node)
@@ -297,7 +296,7 @@ export class Node extends EventEmitter {
             }, this.disconnectionWaitTime)
         }
         if (sendStatus) {
-            this.trackerManager.sendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(spid)
         }
     }
 

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -74,13 +74,15 @@ export class StreamManager {
         const streamState = this.streams.get(spid.toKey())
         if (streamState !== undefined) {
             return {
-                spidKey: spid.toKey(),  
+                id: spid.streamId,
+                partition: spid.streamPartition,
                 neighbors: [...streamState.neighbors],
                 counter: streamState.counter
             }
         } else {
             return {
-                spidKey: spid.toKey(),
+                id: spid.streamId,
+                partition: spid.streamPartition,
                 neighbors: [],
                 counter: COUNTER_UNSUBSCRIBE
             }

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -37,7 +37,7 @@ export class StreamManager {
         messageId: MessageLayer.MessageID,
         previousMessageReference: MessageLayer.MessageRef | null
     ): boolean | never {
-        const spid = new SPID(messageId.streamId, messageId.streamPartition)
+        const spid = SPID.from(messageId)
         this.verifyThatIsSetUp(spid)
 
         const detectorKey = keyForDetector(messageId)

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -1,6 +1,6 @@
-import { StreamIdAndPartition, StreamKey, StreamStatus } from '../../identifiers'
+import { MessageLayer, SPID, SPIDKey } from 'streamr-client-protocol'
+import { StreamStatus } from '../../identifiers'
 import { DuplicateMessageDetector, NumberPair } from './DuplicateMessageDetector'
-import { MessageLayer } from 'streamr-client-protocol'
 import { NodeId } from './Node'
 import { COUNTER_UNSUBSCRIBE } from '../tracker/InstructionCounter'
 import _ from 'lodash'
@@ -16,16 +16,16 @@ function keyForDetector({ publisherId, msgChainId }: MessageLayer.MessageID) {
 }
 
 export class StreamManager {
-    private readonly streams: Map<string, StreamState> = new Map<string, StreamState>() // streamKey => {}
+    private readonly streams: Map<SPIDKey,StreamState> = new Map<SPIDKey,StreamState>() // spidKey => {}
 
-    setUpStream(streamId: StreamIdAndPartition): void {
-        if (!(streamId instanceof StreamIdAndPartition)) {
-            throw new Error('streamId not instance of StreamIdAndPartition')
+    setUpStream(spid: SPID): void {
+        if (!(spid instanceof SPID)) {
+            throw new Error('streamId not instance of SPID')
         }
-        if (this.isSetUp(streamId)) {
-            throw new Error(`Stream ${streamId} already set up`)
+        if (this.isSetUp(spid)) {
+            throw new Error(`Stream ${spid} already set up`)
         }
-        this.streams.set(streamId.key(), {
+        this.streams.set(spid.toKey(), {
             detectors: new Map(),
             neighbors: new Set(),
             counter: 0
@@ -36,11 +36,11 @@ export class StreamManager {
         messageId: MessageLayer.MessageID,
         previousMessageReference: MessageLayer.MessageRef | null
     ): boolean | never {
-        const streamIdAndPartition = new StreamIdAndPartition(messageId.streamId, messageId.streamPartition)
-        this.verifyThatIsSetUp(streamIdAndPartition)
+        const spid = new SPID(messageId.streamId, messageId.streamPartition)
+        this.verifyThatIsSetUp(spid)
 
         const detectorKey = keyForDetector(messageId)
-        const { detectors } = this.streams.get(streamIdAndPartition.key())!
+        const { detectors } = this.streams.get(spid.toKey())!
         if (!detectors.has(detectorKey)) {
             detectors.set(detectorKey, new DuplicateMessageDetector())
         }
@@ -53,57 +53,57 @@ export class StreamManager {
         )
     }
 
-    updateCounter(streamId: StreamIdAndPartition, counter: number): void {
-        this.streams.get(streamId.key())!.counter = counter
+    updateCounter(spid: SPID, counter: number): void {
+        this.streams.get(spid.toKey())!.counter = counter
     }
 
-    addNeighbor(streamId: StreamIdAndPartition, node: NodeId): void {
-        this.verifyThatIsSetUp(streamId)
-        const { neighbors } = this.streams.get(streamId.key())!
+    addNeighbor(spid: SPID, node: NodeId): void {
+        this.verifyThatIsSetUp(spid)
+        const { neighbors } = this.streams.get(spid.toKey())!
         neighbors.add(node)
     }
 
-    removeNodeFromStream(streamId: StreamIdAndPartition, node: NodeId): void {
-        this.verifyThatIsSetUp(streamId)
-        const { neighbors } = this.streams.get(streamId.key())!
+    removeNodeFromStream(spid: SPID, node: NodeId): void {
+        this.verifyThatIsSetUp(spid)
+        const { neighbors } = this.streams.get(spid.toKey())!
         neighbors.delete(node)
     }
 
-    getStreamStatus(streamId: StreamIdAndPartition): StreamStatus {
-        const streamState = this.streams.get(streamId.key())
+    getStreamStatus(spid: SPID): StreamStatus {
+        const streamState = this.streams.get(spid.toKey())
         if (streamState !== undefined) {
             return {
-                streamKey: streamId.key(),
+                spidKey: spid.toKey(),  
                 neighbors: [...streamState.neighbors],
                 counter: streamState.counter
             }
         } else {
             return {
-                streamKey: streamId.key(),
+                spidKey: spid.toKey(),
                 neighbors: [],
                 counter: COUNTER_UNSUBSCRIBE
             }
         }
     }
 
-    removeNodeFromAllStreams(node: NodeId): StreamIdAndPartition[] {
-        const streams: StreamIdAndPartition[] = []
-        this.streams.forEach(({ neighbors }, streamKey) => {
+    removeNodeFromAllStreams(node: NodeId): SPID[] {
+        const streams: SPID[] = []
+        this.streams.forEach(({ neighbors }, spidKey) => {
             const isRemoved = neighbors.delete(node)
             if (isRemoved) {
-                streams.push(StreamIdAndPartition.fromKey(streamKey))
+                streams.push(SPID.from(spidKey))
             }
         })
         return streams
     }
 
-    removeStream(streamId: StreamIdAndPartition): void {
-        this.verifyThatIsSetUp(streamId)
-        this.streams.delete(streamId.key())
+    removeStream(spid: SPID): void {
+        this.verifyThatIsSetUp(spid)
+        this.streams.delete(spid.toKey())
     }
 
-    isSetUp(streamId: StreamIdAndPartition): boolean {
-        return this.streams.has(streamId.key())
+    isSetUp(spid: SPID): boolean {
+        return this.streams.has(spid.toKey())
     }
 
     isNodePresent(node: NodeId): boolean {
@@ -113,29 +113,30 @@ export class StreamManager {
     }
 
     // TODO: rename to getSortedStreams() (or remove sort functionality altogether)
-    getStreams(): ReadonlyArray<StreamIdAndPartition> {
-        return this.getStreamsAsKeys().map((key) => StreamIdAndPartition.fromKey(key))
+    getStreams(): ReadonlyArray<SPID> {
+        return this.getStreamsAsKeys().map((key) => SPID.from(key))
     }
 
-    *getStreamsIterable(): IterableIterator<StreamIdAndPartition> {
-        for (const streamKey of this.getStreamKeys()) {
-            yield StreamIdAndPartition.fromKey(streamKey)
+    // TODO remove this method and use getSPIDKeys?
+    *getStreamsIterable(): IterableIterator<SPID> {
+        for (const spidKey of this.getSPIDKeys()) {
+            yield SPID.from(spidKey)
         }
     }
 
     // efficient way to access streams
-    getStreamKeys(): IterableIterator<StreamKey> {
+    getSPIDKeys(): IterableIterator<SPIDKey> {
         return this.streams.keys()
     }
 
     // TODO: rename to getStreamKeysAsSortedArray (or remove sort functionality altogether)
-    getStreamsAsKeys(): ReadonlyArray<StreamKey> {
+    getStreamsAsKeys(): ReadonlyArray<SPIDKey> {
         return [...this.streams.keys()].sort()
     }
 
-    getNeighborsForStream(streamId: StreamIdAndPartition): ReadonlyArray<NodeId> {
-        this.verifyThatIsSetUp(streamId)
-        return [...this.streams.get(streamId.key())!.neighbors]
+    getNeighborsForStream(spid: SPID): ReadonlyArray<NodeId> {
+        this.verifyThatIsSetUp(spid)
+        return [...this.streams.get(spid.toKey())!.neighbors]
     }
 
     getAllNodes(): ReadonlyArray<NodeId> {
@@ -146,14 +147,14 @@ export class StreamManager {
         return _.uniq(nodes)
     }
 
-    hasNeighbor(streamId: StreamIdAndPartition, node: NodeId): boolean {
-        this.verifyThatIsSetUp(streamId)
-        return this.streams.get(streamId.key())!.neighbors.has(node)
+    hasNeighbor(spid: SPID, node: NodeId): boolean {
+        this.verifyThatIsSetUp(spid)
+        return this.streams.get(spid.toKey())!.neighbors.has(node)
     }
 
-    private verifyThatIsSetUp(streamId: StreamIdAndPartition): void | never {
-        if (!this.isSetUp(streamId)) {
-            throw new Error(`Stream ${streamId} is not set up`)
+    private verifyThatIsSetUp(spid: SPID): void | never {
+        if (!this.isSetUp(spid)) {
+            throw new Error(`Stream ${spid} is not set up`)
         }
     }
 }

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -113,23 +113,12 @@ export class StreamManager {
         })
     }
 
-    // TODO: rename to getSortedStreams() (or remove sort functionality altogether)
-    getStreams(): ReadonlyArray<SPID> {
-        return this.getStreamsAsKeys().map((key) => SPID.from(key))
-    }
-
     getSPIDs(): Iterable<SPID> {
         return transformIterable(this.getSPIDKeys(), (spidKey) => SPID.from(spidKey))
     }
 
-    // efficient way to access streams
     getSPIDKeys(): IterableIterator<SPIDKey> {
         return this.streams.keys()
-    }
-
-    // TODO: rename to getStreamKeysAsSortedArray (or remove sort functionality altogether)
-    getStreamsAsKeys(): ReadonlyArray<SPIDKey> {
-        return [...this.streams.keys()].sort()
     }
 
     getNeighborsForStream(spid: SPID): ReadonlyArray<NodeId> {

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -17,7 +17,7 @@ function keyForDetector({ publisherId, msgChainId }: MessageLayer.MessageID) {
 }
 
 export class StreamManager {
-    private readonly streams: Map<SPIDKey,StreamState> = new Map<SPIDKey,StreamState>() // spidKey => {}
+    private readonly streams: Map<SPIDKey,StreamState> = new Map<SPIDKey,StreamState>()
 
     setUpStream(spid: SPID): void {
         if (!(spid instanceof SPID)) {

--- a/packages/network/src/logic/node/StreamManager.ts
+++ b/packages/network/src/logic/node/StreamManager.ts
@@ -4,6 +4,7 @@ import { DuplicateMessageDetector, NumberPair } from './DuplicateMessageDetector
 import { NodeId } from './Node'
 import { COUNTER_UNSUBSCRIBE } from '../tracker/InstructionCounter'
 import _ from 'lodash'
+import { transformIterable } from '../../helpers/transformIterable'
 
 interface StreamState {
     detectors: Map<string, DuplicateMessageDetector> // "publisherId-msgChainId" => DuplicateMessageDetector
@@ -117,11 +118,8 @@ export class StreamManager {
         return this.getStreamsAsKeys().map((key) => SPID.from(key))
     }
 
-    // TODO remove this method and use getSPIDKeys?
-    *getStreamsIterable(): IterableIterator<SPID> {
-        for (const spidKey of this.getSPIDKeys()) {
-            yield SPID.from(spidKey)
-        }
+    getSPIDs(): Iterable<SPID> {
+        return transformIterable(this.getSPIDKeys(), (spidKey) => SPID.from(spidKey))
     }
 
     // efficient way to access streams

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -40,8 +40,8 @@ export class TrackerConnector {
         this.connectionStates = new Map()
     }
 
-    onNewStream(streamId: SPID): void {
-        const trackerInfo = this.trackerRegistry.getTracker(streamId.streamId, streamId.streamPartition)
+    onNewStream(spid: SPID): void {
+        const trackerInfo = this.trackerRegistry.getTracker(spid.streamId, spid.streamPartition)
         this.connectTo(trackerInfo)
     }
 

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -1,5 +1,5 @@
-import { Utils } from 'streamr-client-protocol'
-import { StreamIdAndPartition, TrackerInfo } from '../../identifiers'
+import { SPID, Utils } from 'streamr-client-protocol'
+import { TrackerInfo } from '../../identifiers'
 import { Logger } from '../../helpers/Logger'
 import { PeerInfo } from '../../connection/PeerInfo'
 import { TrackerId } from '../tracker/Tracker'
@@ -12,7 +12,7 @@ enum ConnectionState {
     ERROR
 }
 
-type GetStreamsFn = () => Iterable<StreamIdAndPartition>
+type GetStreamsFn = () => Iterable<SPID>
 type ConnectToTrackerFn = (trackerAddress: string, trackerPeerInfo: PeerInfo) => Promise<unknown>
 type DisconnectFromTrackerFn = (trackerId: TrackerId) => void
 
@@ -40,8 +40,8 @@ export class TrackerConnector {
         this.connectionStates = new Map()
     }
 
-    onNewStream(streamId: StreamIdAndPartition): void {
-        const trackerInfo = this.trackerRegistry.getTracker(streamId.id, streamId.partition)
+    onNewStream(streamId: SPID): void {
+        const trackerInfo = this.trackerRegistry.getTracker(streamId.streamId, streamId.streamPartition)
         this.connectTo(trackerInfo)
     }
 
@@ -90,8 +90,8 @@ export class TrackerConnector {
     }
 
     private isActiveTracker(trackerId: TrackerId): boolean {
-        for (const { id: streamId, partition } of this.getStreams()) {
-            if (this.trackerRegistry.getTracker(streamId, partition).id === trackerId) {
+        for (const { streamId, streamPartition } of this.getStreams()) {
+            if (this.trackerRegistry.getTracker(streamId, streamPartition).id === trackerId) {
                 return true
             }
         }

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -12,12 +12,12 @@ enum ConnectionState {
     ERROR
 }
 
-type GetStreamsFn = () => Iterable<SPID>
+type GetSPIDsFn = () => Iterable<SPID>
 type ConnectToTrackerFn = (trackerAddress: string, trackerPeerInfo: PeerInfo) => Promise<unknown>
 type DisconnectFromTrackerFn = (trackerId: TrackerId) => void
 
 export class TrackerConnector {
-    private readonly getStreams: GetStreamsFn
+    private readonly getSPIDs: GetSPIDsFn
     private readonly connectToTracker: ConnectToTrackerFn
     private readonly disconnectFromTracker: DisconnectFromTrackerFn
     private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
@@ -26,13 +26,13 @@ export class TrackerConnector {
     private connectionStates: Map<TrackerId, ConnectionState>
 
     constructor(
-        getStreams: GetStreamsFn,
+        getSPIDs: GetSPIDsFn,
         connectToTracker: ConnectToTrackerFn,
         disconnectFromTracker: DisconnectFromTrackerFn,
         trackerRegistry: Utils.TrackerRegistry<TrackerInfo>,
         maintenanceInterval: number
     ) {
-        this.getStreams = getStreams
+        this.getSPIDs = getSPIDs
         this.connectToTracker = connectToTracker
         this.disconnectFromTracker = disconnectFromTracker
         this.trackerRegistry = trackerRegistry
@@ -90,7 +90,7 @@ export class TrackerConnector {
     }
 
     private isActiveTracker(trackerId: TrackerId): boolean {
-        for (const { streamId, streamPartition } of this.getStreams()) {
+        for (const { streamId, streamPartition } of this.getSPIDs()) {
             if (this.trackerRegistry.getTracker(streamId, streamPartition).id === trackerId) {
                 return true
             }

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -41,7 +41,7 @@ export class TrackerConnector {
     }
 
     onNewStream(spid: SPID): void {
-        const trackerInfo = this.trackerRegistry.getTracker(spid.streamId, spid.streamPartition)
+        const trackerInfo = this.trackerRegistry.getTracker(spid)
         this.connectTo(trackerInfo)
     }
 
@@ -91,7 +91,7 @@ export class TrackerConnector {
 
     private isActiveTracker(trackerId: TrackerId): boolean {
         for (const { streamId, streamPartition } of this.getSPIDs()) {
-            if (this.trackerRegistry.getTracker(streamId, streamPartition).id === trackerId) {
+            if (this.trackerRegistry.getTracker(new SPID(streamId, streamPartition)).id === trackerId) {
                 return true
             }
         }

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -161,7 +161,7 @@ export class TrackerManager {
         trackerId: TrackerId,
         reattempt = false
     ): Promise<void> {
-        const spid = SPID.from(instructionMessage)
+        const spid = instructionMessage.getSPID()
         const { nodeIds, counter } = instructionMessage
 
         this.instructionRetryManager.add(instructionMessage, trackerId)

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -71,7 +71,7 @@ export class TrackerManager {
         this.subscriber = subscriber
         this.rttUpdateInterval = opts.rttUpdateTimeout || 15000
         this.trackerConnector = new TrackerConnector(
-            streamManager.getStreamsIterable.bind(streamManager),
+            streamManager.getSPIDs.bind(streamManager),
             this.nodeToTracker.connectToTracker.bind(this.nodeToTracker),
             this.nodeToTracker.disconnectFromTracker.bind(this.nodeToTracker),
             this.trackerRegistry,

--- a/packages/network/src/logic/node/propagation/Propagation.ts
+++ b/packages/network/src/logic/node/propagation/Propagation.ts
@@ -1,9 +1,8 @@
-import { StreamMessage } from 'streamr-client-protocol'
+import { SPID, StreamMessage } from 'streamr-client-protocol'
 import { NodeId } from '../Node'
-import { StreamIdAndPartition } from '../../../identifiers'
 import { PropagationTaskStore } from './PropagationTaskStore'
 
-type GetNeighborsFn = (stream: StreamIdAndPartition) => ReadonlyArray<NodeId>
+type GetNeighborsFn = (spid: SPID) => ReadonlyArray<NodeId>
 
 type SendToNeighborFn = (neighborId: NodeId, msg: StreamMessage) => void
 
@@ -49,8 +48,8 @@ export class Propagation {
      * Node should invoke this when it learns about a new message
      */
     feedUnseenMessage(message: StreamMessage, source: NodeId | null): void {
-        const stream = StreamIdAndPartition.fromMessage(message.messageId)
-        const targetNeighbors = this.getNeighbors(stream).filter((n) => n !== source)
+        const spid = SPID.from(message.messageId)
+        const targetNeighbors = this.getNeighbors(spid).filter((n) => n !== source)
 
         targetNeighbors.forEach((neighborId) => {
             this.sendToNeighbor(neighborId, message)
@@ -68,8 +67,8 @@ export class Propagation {
     /**
      * Node should invoke this when it learns about a new node stream assignment
      */
-    onNeighborJoined(neighborId: NodeId, stream: StreamIdAndPartition): void {
-        const tasksOfStream = this.activeTaskStore.get(stream)
+    onNeighborJoined(neighborId: NodeId, spid: SPID): void {
+        const tasksOfStream = this.activeTaskStore.get(spid)
         tasksOfStream.forEach(({ handledNeighbors, source, message}) => {
             if (!handledNeighbors.has(neighborId) && neighborId !== source) {
                 this.sendToNeighbor(neighborId, message)

--- a/packages/network/src/logic/node/propagation/Propagation.ts
+++ b/packages/network/src/logic/node/propagation/Propagation.ts
@@ -48,7 +48,7 @@ export class Propagation {
      * Node should invoke this when it learns about a new message
      */
     feedUnseenMessage(message: StreamMessage, source: NodeId | null): void {
-        const spid = SPID.from(message.messageId)
+        const spid = message.getSPID()
         const targetNeighbors = this.getNeighbors(spid).filter((n) => n !== source)
 
         targetNeighbors.forEach((neighborId) => {

--- a/packages/network/src/logic/node/propagation/PropagationTaskStore.ts
+++ b/packages/network/src/logic/node/propagation/PropagationTaskStore.ts
@@ -25,12 +25,12 @@ export class PropagationTaskStore {
             ttlInMs,
             maxSize: maxTasks,
             onItemDropped: (messageId: MessageID) => {
-                const stream = SPID.from(messageId)
-                const messageIdsForStream = this.streamLookup.get(stream.toKey())
+                const spid = SPID.from(messageId)
+                const messageIdsForStream = this.streamLookup.get(spid.toKey())
                 if (messageIdsForStream !== undefined) {
                     messageIdsForStream.delete(messageId)
                     if (messageIdsForStream.size === 0) {
-                        this.streamLookup.delete(stream.toKey())
+                        this.streamLookup.delete(spid.toKey())
                     }
                 }
             }

--- a/packages/network/src/logic/node/propagation/PropagationTaskStore.ts
+++ b/packages/network/src/logic/node/propagation/PropagationTaskStore.ts
@@ -1,5 +1,4 @@
-import { MessageID, StreamMessage } from 'streamr-client-protocol'
-import { StreamIdAndPartition, StreamKey } from '../../../identifiers'
+import { MessageID, SPID, SPIDKey, StreamMessage } from 'streamr-client-protocol'
 import { FifoMapWithTtl } from './FifoMapWithTtl'
 import { NodeId } from '../Node'
 
@@ -13,12 +12,12 @@ export interface PropagationTask {
  * Keeps track of propagation tasks for the needs of message propagation logic.
  *
  * Properties:
- * - Allows fetching propagation tasks by StreamIdAndPartition
+ * - Allows fetching propagation tasks by SPID
  * - Upper bound on number of tasks stored, replacement policy if FIFO
  * - Items have a TTL, after which they are considered stale and not returned when querying
 **/
 export class PropagationTaskStore {
-    private readonly streamLookup = new Map<StreamKey, Set<MessageID>>()
+    private readonly streamLookup = new Map<SPIDKey, Set<MessageID>>()
     private readonly tasks: FifoMapWithTtl<MessageID, PropagationTask>
 
     constructor(ttlInMs: number, maxTasks: number) {
@@ -26,12 +25,12 @@ export class PropagationTaskStore {
             ttlInMs,
             maxSize: maxTasks,
             onItemDropped: (messageId: MessageID) => {
-                const stream = StreamIdAndPartition.fromMessage(messageId)
-                const messageIdsForStream = this.streamLookup.get(stream.key())
+                const stream = SPID.from(messageId)
+                const messageIdsForStream = this.streamLookup.get(stream.toKey())
                 if (messageIdsForStream !== undefined) {
                     messageIdsForStream.delete(messageId)
                     if (messageIdsForStream.size === 0) {
-                        this.streamLookup.delete(stream.key())
+                        this.streamLookup.delete(stream.toKey())
                     }
                 }
             }
@@ -40,11 +39,11 @@ export class PropagationTaskStore {
 
     add(task: PropagationTask): void {
         const messageId = task.message.messageId
-        const stream = StreamIdAndPartition.fromMessage(messageId)
-        if (!this.streamLookup.has(stream.key())) {
-            this.streamLookup.set(stream.key(), new Set<MessageID>())
+        const spidKey = SPID.from(messageId).toKey()
+        if (!this.streamLookup.has(spidKey)) {
+            this.streamLookup.set(spidKey, new Set<MessageID>())
         }
-        this.streamLookup.get(stream.key())!.add(messageId)
+        this.streamLookup.get(spidKey)!.add(messageId)
         this.tasks.set(messageId, task)
     }
 
@@ -52,8 +51,8 @@ export class PropagationTaskStore {
         this.tasks.delete(messageId) // causes `onKeyDropped` to be invoked
     }
 
-    get(stream: StreamIdAndPartition): Array<PropagationTask> {
-        const messageIds = this.streamLookup.get(stream.key())
+    get(spid: SPID): Array<PropagationTask> {
+        const messageIds = this.streamLookup.get(spid.toKey())
         const tasks: Array<PropagationTask> = []
         if (messageIds !== undefined) {
             messageIds.forEach((messageId) => {

--- a/packages/network/src/logic/tracker/InstructionCounter.ts
+++ b/packages/network/src/logic/tracker/InstructionCounter.ts
@@ -18,7 +18,7 @@ export class InstructionCounter {
     }
 
     isMostRecent(status: Status, source: NodeId): boolean {
-        const spidKey = new SPID(status.stream.id, status.stream.partition).toKey()
+        const spidKey = SPID.toKey(status.stream.id, status.stream.partition)
         const currentCounter = this.getAndSetIfNecessary(source, spidKey)
         return (status.stream.counter >= currentCounter || status.stream.counter === COUNTER_UNSUBSCRIBE)
     }

--- a/packages/network/src/logic/tracker/InstructionCounter.ts
+++ b/packages/network/src/logic/tracker/InstructionCounter.ts
@@ -1,4 +1,4 @@
-import { SPIDKey } from 'streamr-client-protocol'
+import { SPID, SPIDKey } from 'streamr-client-protocol'
 import { Status } from '../../identifiers'
 import { NodeId } from '../node/Node'
 
@@ -18,7 +18,8 @@ export class InstructionCounter {
     }
 
     isMostRecent(status: Status, source: NodeId): boolean {
-        const currentCounter = this.getAndSetIfNecessary(source, status.stream.spidKey)
+        const spidKey = new SPID(status.stream.id, status.stream.partition).toKey()
+        const currentCounter = this.getAndSetIfNecessary(source, spidKey)
         return (status.stream.counter >= currentCounter || status.stream.counter === COUNTER_UNSUBSCRIBE)
     }
 

--- a/packages/network/src/logic/tracker/InstructionCounter.ts
+++ b/packages/network/src/logic/tracker/InstructionCounter.ts
@@ -1,23 +1,24 @@
-import { Status, StreamKey } from '../../identifiers'
+import { SPIDKey } from 'streamr-client-protocol'
+import { Status } from '../../identifiers'
 import { NodeId } from '../node/Node'
 
 export const COUNTER_UNSUBSCRIBE = -1
 
-type Counters = Record<NodeId,Record<StreamKey,number>>
+type Counters = Record<NodeId,Record<SPIDKey,number>>
 
 export class InstructionCounter {
     private readonly counters: Counters = {}
 
     constructor() {}
 
-    setOrIncrement(nodeId: NodeId, streamKey: StreamKey): number {
-        this.getAndSetIfNecessary(nodeId, streamKey)
-        this.counters[nodeId][streamKey] += 1
-        return this.counters[nodeId][streamKey]
+    setOrIncrement(nodeId: NodeId, spidKey: SPIDKey): number {
+        this.getAndSetIfNecessary(nodeId, spidKey)
+        this.counters[nodeId][spidKey] += 1
+        return this.counters[nodeId][spidKey]
     }
 
     isMostRecent(status: Status, source: NodeId): boolean {
-        const currentCounter = this.getAndSetIfNecessary(source, status.stream.streamKey)
+        const currentCounter = this.getAndSetIfNecessary(source, status.stream.spidKey)
         return (status.stream.counter >= currentCounter || status.stream.counter === COUNTER_UNSUBSCRIBE)
     }
 
@@ -25,19 +26,19 @@ export class InstructionCounter {
         delete this.counters[nodeId]
     }
 
-    removeStream(streamKey: StreamKey): void {
+    removeStream(spidKey: SPIDKey): void {
         Object.keys(this.counters).forEach((nodeId) => {
-            delete this.counters[nodeId][streamKey]
+            delete this.counters[nodeId][spidKey]
         })
     }
 
-    private getAndSetIfNecessary(nodeId: NodeId, streamKey: StreamKey): number {
+    private getAndSetIfNecessary(nodeId: NodeId, spidKey: SPIDKey): number {
         if (this.counters[nodeId] === undefined) {
             this.counters[nodeId] = {}
         }
-        if (this.counters[nodeId][streamKey] === undefined) {
-            this.counters[nodeId][streamKey] = 0
+        if (this.counters[nodeId][spidKey] === undefined) {
+            this.counters[nodeId][spidKey] = 0
         }
-        return this.counters[nodeId][streamKey]
+        return this.counters[nodeId][spidKey]
     }
 }

--- a/packages/network/src/logic/tracker/InstructionCounter.ts
+++ b/packages/network/src/logic/tracker/InstructionCounter.ts
@@ -4,7 +4,7 @@ import { NodeId } from '../node/Node'
 
 export const COUNTER_UNSUBSCRIBE = -1
 
-type Counters = Record<NodeId,Record<SPIDKey,number>>
+type Counters = Record<NodeId, Record<SPIDKey, number>>
 
 export class InstructionCounter {
     private readonly counters: Counters = {}

--- a/packages/network/src/logic/tracker/Tracker.ts
+++ b/packages/network/src/logic/tracker/Tracker.ts
@@ -13,10 +13,9 @@ import { Location, Status, StreamStatus } from '../../identifiers'
 import { TrackerLayer } from 'streamr-client-protocol'
 import { NodeId } from '../node/Node'
 import { InstructionSender } from './InstructionSender'
+import { transformIterable } from '../../helpers/transformIterable'
 
 export type TrackerId = string
-
-type StreamId = string
 
 export enum Event {
     NODE_CONNECTED = 'streamr:tracker:node-connected'
@@ -232,8 +231,8 @@ export class Tracker extends EventEmitter {
         }
     }
 
-    getStreams(): ReadonlyArray<StreamId> {
-        return Object.keys(this.overlayPerStream)
+    getSPIDs(): Iterable<SPID> {
+        return transformIterable(Object.keys(this.overlayPerStream), (spidKey) => SPID.from(spidKey))
     }
 
     getAllNodeLocations(): Readonly<Record<NodeId,Location>> {

--- a/packages/network/src/logic/tracker/Tracker.ts
+++ b/packages/network/src/logic/tracker/Tracker.ts
@@ -169,7 +169,7 @@ export class Tracker extends EventEmitter {
         })
         this.extraMetadatas[source] = extra
 
-        const spidKey = new SPID(stream.id, stream.partition).toKey()
+        const spidKey = SPID.toKey(stream.id, stream.partition)
 
         // update topology
         this.createTopology(spidKey)
@@ -194,7 +194,7 @@ export class Tracker extends EventEmitter {
     }
 
     private updateNodeOnStream(node: NodeId, status: StreamStatus): void {
-        const spidKey = new SPID(status.id, status.partition).toKey()
+        const spidKey = SPID.toKey(status.id, status.partition)
         if (status.counter === COUNTER_UNSUBSCRIBE) {
             this.leaveAndCheckEmptyOverlay(spidKey, this.overlayPerStream[spidKey], node)
         } else {

--- a/packages/network/src/logic/tracker/trackerSummaryUtils.ts
+++ b/packages/network/src/logic/tracker/trackerSummaryUtils.ts
@@ -1,8 +1,8 @@
-import { SPID } from 'streamr-client-protocol'
+import { SPID, SPIDKey } from 'streamr-client-protocol'
 import { NodeId } from '../node/Node'
 import { OverlayPerStream, OverlayConnectionRtts } from './Tracker'
 
-type OverLayWithRtts = { [key: string]: Record<NodeId,{ neighborId: NodeId, rtt: number | null }[] > }
+type OverLayWithRtts = Record<SPIDKey,Record<NodeId,{ neighborId: NodeId, rtt: number | null }[] >>
 type OverlaySizes = { streamId: string, partition: number, nodeCount: number }[]
 
 export function getTopology(

--- a/packages/network/src/protocol/TrackerServer.ts
+++ b/packages/network/src/protocol/TrackerServer.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events'
 import { v4 as uuidv4 } from 'uuid'
-import { TrackerLayer, TrackerMessageType } from 'streamr-client-protocol'
+import { SPID, TrackerLayer, TrackerMessageType } from 'streamr-client-protocol'
 import { Logger } from '../helpers/Logger'
 import { decode } from './utils'
-import { RtcSubTypes, StreamIdAndPartition } from '../identifiers'
+import { RtcSubTypes } from '../identifiers'
 import { PeerId, PeerInfo } from '../connection/PeerInfo'
 import { NameDirectory } from '../NameDirectory'
 import { ServerWsEndpoint } from "../connection/ws/ServerWsEndpoint"
@@ -43,13 +43,13 @@ export class TrackerServer extends EventEmitter {
 
     async sendInstruction(
         receiverNodeId: NodeId, 
-        streamId: StreamIdAndPartition, 
+        spid: SPID, 
         nodeIds: NodeId[], counter: number
     ): Promise<void> {
         await this.send(receiverNodeId, new TrackerLayer.InstructionMessage({
             requestId: uuidv4(),
-            streamId: streamId.id,
-            streamPartition: streamId.partition,
+            streamId: spid.streamId,
+            streamPartition: spid.streamPartition,
             nodeIds,
             counter
         }))

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -13,7 +13,7 @@ const WAIT_TIME = 2000
 
 const formStatus = (counter1: number, nodes1: NodeId[]): Partial<Status> => ({
     stream: {
-        streamKey: 'stream-1::0',
+        spidKey: 'stream-1#0',
         neighbors: nodes1,
         counter: counter1
     }

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -13,7 +13,8 @@ const WAIT_TIME = 2000
 
 const formStatus = (counter1: number, nodes1: NodeId[]): Partial<Status> => ({
     stream: {
-        spidKey: 'stream-1#0',
+        id: 'stream-1',
+        partition: 0,
         neighbors: nodes1,
         counter: counter1
     }

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -1,7 +1,5 @@
-import { MessageLayer, ControlLayer, TrackerLayer } from 'streamr-client-protocol'
+import { MessageLayer, ControlLayer, TrackerLayer, SPID } from 'streamr-client-protocol'
 import { waitForEvent } from 'streamr-test-utils'
-
-import { StreamIdAndPartition } from '../../src/identifiers'
 import { NodeToNode, Event as NodeToNodeEvent } from '../../src/protocol/NodeToNode'
 import { NodeToTracker, Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { TrackerServer, Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
@@ -156,7 +154,7 @@ describe('delivery of messages in protocol layer', () => {
     })
 
     it('sendInstruction is delivered', async () => {
-        trackerServer.sendInstruction('node1', new StreamIdAndPartition('stream', 10), ['node1'], 15)
+        trackerServer.sendInstruction('node1', new SPID('stream', 10), ['node1'], 15)
         const [msg, trackerId]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED)
 
         expect(trackerId).toEqual('trackerServer')

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -9,13 +9,13 @@ import { Event as NodeEvent } from '../../src/logic/node/Node'
 import { getSPIDKeys } from '../utils'
 
 // TODO: maybe worth re-designing this in a way that isn't this arbitrary?
-const FIRST_STREAM = 'stream-1' // assigned to trackerOne (arbitrarily by hashing algo)
-const SECOND_STREAM = 'stream-3' // assigned to trackerTwo
-const THIRD_STREAM = 'stream-2' // assigned to trackerThree
+const FIRST_STREAM = 'a-0' // assigned to trackerOne (arbitrarily by hashing algo)
+const SECOND_STREAM = 'b-8' // assigned to trackerTwo
+const THIRD_STREAM = 'c-2' // assigned to trackerThree
 
-const FIRST_STREAM_2 = 'stream-13' // assigned to trackerOne
-const SECOND_STREAM_2 = 'stream-10' // assigned to trackerTwo
-const THIRD_STREAM_2 = 'stream-15' // assigned to trackerThree
+const FIRST_STREAM_2 = 'e-1' // assigned to trackerOne
+const SECOND_STREAM_2 = 'f-3' // assigned to trackerTwo
+const THIRD_STREAM_2 = 'g-0' // assigned to trackerThree
 
 // Leave out WebRTC related events
 const TRACKER_NODE_EVENTS_OF_INTEREST = [

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -6,6 +6,7 @@ import { TrackerLayer } from 'streamr-client-protocol'
 import { createNetworkNode, startTracker } from '../../src/composition'
 import { Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { Event as NodeEvent } from '../../src/logic/node/Node'
+import { getSPIDKeys } from '../utils'
 
 // TODO: maybe worth re-designing this in a way that isn't this arbitrary?
 const FIRST_STREAM = 'stream-1' // assigned to trackerOne (arbitrarily by hashing algo)
@@ -88,27 +89,27 @@ describe('multi trackers', () => {
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).toContain(`${FIRST_STREAM}#0`)
-        expect(trackerTwo.getStreams()).not.toContain(`${FIRST_STREAM}#0`)
-        expect(trackerThree.getStreams()).not.toContain(`${FIRST_STREAM}#0`)
+        expect(getSPIDKeys(trackerOne)).toContain(`${FIRST_STREAM}#0`)
+        expect(getSPIDKeys(trackerTwo)).not.toContain(`${FIRST_STREAM}#0`)
+        expect(getSPIDKeys(trackerThree)).not.toContain(`${FIRST_STREAM}#0`)
 
         // second stream, second tracker
         nodeOne.subscribe(SECOND_STREAM, 0)
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).not.toContain(`${SECOND_STREAM}#0`)
-        expect(trackerTwo.getStreams()).toContain(`${SECOND_STREAM}#0`)
-        expect(trackerThree.getStreams()).not.toContain(`${SECOND_STREAM}#0`)
+        expect(getSPIDKeys(trackerOne)).not.toContain(`${SECOND_STREAM}#0`)
+        expect(getSPIDKeys(trackerTwo)).toContain(`${SECOND_STREAM}#0`)
+        expect(getSPIDKeys(trackerThree)).not.toContain(`${SECOND_STREAM}#0`)
 
         // third stream, third tracker
         nodeOne.subscribe(THIRD_STREAM, 0)
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).not.toContain(`${THIRD_STREAM}#0`)
-        expect(trackerTwo.getStreams()).not.toContain(`${THIRD_STREAM}#0`)
-        expect(trackerThree.getStreams()).toContain(`${THIRD_STREAM}#0`)
+        expect(getSPIDKeys(trackerOne)).not.toContain(`${THIRD_STREAM}#0`)
+        expect(getSPIDKeys(trackerTwo)).not.toContain(`${THIRD_STREAM}#0`)
+        expect(getSPIDKeys(trackerThree)).toContain(`${THIRD_STREAM}#0`)
     })
 
     test('only one specific tracker sends instructions about stream', async () => {
@@ -183,6 +184,6 @@ describe('multi trackers', () => {
         })
         // @ts-expect-error private field
         await nodeOne.trackerManager.handleTrackerInstruction(unexpectedInstruction, 'trackerOne')
-        expect(nodeOne.getStreams()).not.toContain('stream-2#0')
+        expect(getSPIDKeys(nodeOne)).not.toContain('stream-2#0')
     })
 })

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -88,27 +88,27 @@ describe('multi trackers', () => {
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).toContain(`${FIRST_STREAM}::0`)
-        expect(trackerTwo.getStreams()).not.toContain(`${FIRST_STREAM}::0`)
-        expect(trackerThree.getStreams()).not.toContain(`${FIRST_STREAM}::0`)
+        expect(trackerOne.getStreams()).toContain(`${FIRST_STREAM}#0`)
+        expect(trackerTwo.getStreams()).not.toContain(`${FIRST_STREAM}#0`)
+        expect(trackerThree.getStreams()).not.toContain(`${FIRST_STREAM}#0`)
 
         // second stream, second tracker
         nodeOne.subscribe(SECOND_STREAM, 0)
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).not.toContain(`${SECOND_STREAM}::0`)
-        expect(trackerTwo.getStreams()).toContain(`${SECOND_STREAM}::0`)
-        expect(trackerThree.getStreams()).not.toContain(`${SECOND_STREAM}::0`)
+        expect(trackerOne.getStreams()).not.toContain(`${SECOND_STREAM}#0`)
+        expect(trackerTwo.getStreams()).toContain(`${SECOND_STREAM}#0`)
+        expect(trackerThree.getStreams()).not.toContain(`${SECOND_STREAM}#0`)
 
         // third stream, third tracker
         nodeOne.subscribe(THIRD_STREAM, 0)
 
         await wait(500)
 
-        expect(trackerOne.getStreams()).not.toContain(`${THIRD_STREAM}::0`)
-        expect(trackerTwo.getStreams()).not.toContain(`${THIRD_STREAM}::0`)
-        expect(trackerThree.getStreams()).toContain(`${THIRD_STREAM}::0`)
+        expect(trackerOne.getStreams()).not.toContain(`${THIRD_STREAM}#0`)
+        expect(trackerTwo.getStreams()).not.toContain(`${THIRD_STREAM}#0`)
+        expect(trackerThree.getStreams()).toContain(`${THIRD_STREAM}#0`)
     })
 
     test('only one specific tracker sends instructions about stream', async () => {
@@ -183,6 +183,6 @@ describe('multi trackers', () => {
         })
         // @ts-expect-error private field
         await nodeOne.trackerManager.handleTrackerInstruction(unexpectedInstruction, 'trackerOne')
-        expect(nodeOne.getStreams()).not.toContain('stream-2::0')
+        expect(nodeOne.getStreams()).not.toContain('stream-2#0')
     })
 })

--- a/packages/network/test/integration/tracker-endpoints.test.ts
+++ b/packages/network/test/integration/tracker-endpoints.test.ts
@@ -95,25 +95,25 @@ describe('tracker endpoint', () => {
     it('/topology/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/topology/`)
         expect(status).toEqual(200)
-        expect(jsonResult['stream-1::0']).not.toBeUndefined()
-        expect(jsonResult['stream-2::0']).not.toBeUndefined()
-        expect(jsonResult['sandbox/test/stream-3::0']).not.toBeUndefined()
+        expect(jsonResult['stream-1#0']).not.toBeUndefined()
+        expect(jsonResult['stream-2#0']).not.toBeUndefined()
+        expect(jsonResult['sandbox/test/stream-3#0']).not.toBeUndefined()
     })
 
     it('/topology/stream-1/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/topology/stream-1/`)
         expect(status).toEqual(200)
-        expect(jsonResult['stream-1::0']).not.toBeUndefined()
-        expect(jsonResult['stream-2::0']).toBeUndefined()
-        expect(jsonResult['sandbox/test/stream-3::0']).toBeUndefined()
+        expect(jsonResult['stream-1#0']).not.toBeUndefined()
+        expect(jsonResult['stream-2#0']).toBeUndefined()
+        expect(jsonResult['sandbox/test/stream-3#0']).toBeUndefined()
     })
 
     it('/topology/sandbox%2test%2stream-3/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/topology/sandbox%2Ftest%2Fstream-3/`)
         expect(status).toEqual(200)
-        expect(jsonResult['stream-1::0']).toBeUndefined()
-        expect(jsonResult['stream-2::0']).toBeUndefined()
-        expect(jsonResult['sandbox/test/stream-3::0']).not.toBeUndefined()
+        expect(jsonResult['stream-1#0']).toBeUndefined()
+        expect(jsonResult['stream-2#0']).toBeUndefined()
+        expect(jsonResult['sandbox/test/stream-3#0']).not.toBeUndefined()
     })
 
     it('/topology/non-existing-stream/', async () => {
@@ -133,17 +133,17 @@ describe('tracker endpoint', () => {
     it('/topology/stream-1/0/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/topology/stream-1/0/`)
         expect(status).toEqual(200)
-        expect(jsonResult['stream-1::0']).not.toBeUndefined()
-        expect(jsonResult['stream-2::0']).toBeUndefined()
-        expect(jsonResult['sandbox/test/stream-3::0']).toBeUndefined()
+        expect(jsonResult['stream-1#0']).not.toBeUndefined()
+        expect(jsonResult['stream-2#0']).toBeUndefined()
+        expect(jsonResult['sandbox/test/stream-3#0']).toBeUndefined()
     })
 
     it('/topology/sandbox%2test%2stream-3/0/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/topology/sandbox%2Ftest%2Fstream-3/0/`)
         expect(status).toEqual(200)
-        expect(jsonResult['stream-1::0']).toBeUndefined()
-        expect(jsonResult['stream-2::0']).toBeUndefined()
-        expect(jsonResult['sandbox/test/stream-3::0']).not.toBeUndefined()
+        expect(jsonResult['stream-1#0']).toBeUndefined()
+        expect(jsonResult['stream-2#0']).toBeUndefined()
+        expect(jsonResult['sandbox/test/stream-3#0']).not.toBeUndefined()
     })
 
     it('/topology/non-existing-stream/0/', async () => {

--- a/packages/network/test/integration/tracker-instructions.test.ts
+++ b/packages/network/test/integration/tracker-instructions.test.ts
@@ -1,12 +1,10 @@
 import { Tracker } from '../../src/logic/tracker/Tracker'
 import { NetworkNode } from '../../src/logic/node/NetworkNode'
 import { waitForCondition, waitForEvent } from 'streamr-test-utils'
-import { TrackerLayer } from 'streamr-client-protocol'
-
+import { SPID, TrackerLayer } from 'streamr-client-protocol'
 import { createNetworkNode, startTracker } from '../../src/composition'
 import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { Event as NodeEvent } from '../../src/logic/node/Node'
-import { StreamIdAndPartition } from '../../src/identifiers'
 import { getTopology } from '../../src/logic/tracker/trackerSummaryUtils'
 
 describe('check tracker, nodes and statuses from nodes', () => {
@@ -16,7 +14,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
     let node1: NetworkNode
     let node2: NetworkNode
 
-    const s1 = new StreamIdAndPartition('stream-1', 0)
+    const s1 = new SPID('stream-1', 0)
 
     beforeEach(async () => {
         tracker = await startTracker({
@@ -64,16 +62,16 @@ describe('check tracker, nodes and statuses from nodes', () => {
     it('if failed to follow tracker instructions, inform tracker about current status', async () => {
         const trackerInstruction1 = new TrackerLayer.InstructionMessage({
             requestId: 'requestId',
-            streamId: s1.id,
-            streamPartition: s1.partition,
+            streamId: s1.streamId,
+            streamPartition: s1.streamPartition,
             nodeIds: ['node2', 'unknown'],
             counter: 0
         })
 
         const trackerInstruction2 = new TrackerLayer.InstructionMessage({
             requestId: 'requestId',
-            streamId: s1.id,
-            streamPartition: s1.partition,
+            streamId: s1.streamId,
+            streamPartition: s1.streamPartition,
             nodeIds: ['node1', 'unknown'],
             counter: 0
         })
@@ -101,7 +99,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
         await waitForCondition(() => node2.getNeighbors().length > 0)
 
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-1::0': {
+            'stream-1#0': {
                 node1: [{neighborId: 'node2', rtt: null}],
                 node2: [{neighborId: 'node1', rtt: null}],
             }

--- a/packages/network/test/integration/tracker-node-reconnect-instructions.test.ts
+++ b/packages/network/test/integration/tracker-node-reconnect-instructions.test.ts
@@ -1,12 +1,10 @@
 import { Tracker } from '../../src/logic/tracker/Tracker'
 import { NetworkNode } from '../../src/logic/node/NetworkNode'
 import { runAndWaitForEvents, waitForEvent } from 'streamr-test-utils'
-import { TrackerLayer } from 'streamr-client-protocol'
-
+import { SPID, TrackerLayer } from 'streamr-client-protocol'
 import { createNetworkNode, startTracker } from '../../src/composition'
 import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { Event as NodeEvent } from '../../src/logic/node/Node'
-import { StreamIdAndPartition } from "../../src/identifiers"
 
 /**
  * This test verifies that tracker can send instructions to node and node will connect and disconnect based on the instructions
@@ -72,12 +70,12 @@ describe('Check tracker instructions to node', () => {
             waitForEvent(nodeTwo, NodeEvent.NODE_SUBSCRIBED)
         ])
 
-        const streamIdAndPartition = new StreamIdAndPartition(streamId, 0)
+        const spid = new SPID(streamId, 0)
 
         // @ts-expect-error private field
-        expect(nodeOne.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(1)
+        expect(nodeOne.streams.getNeighborsForStream(spid).length).toBe(1)
         // @ts-expect-error private field
-        expect(nodeTwo.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(1)
+        expect(nodeTwo.streams.getNeighborsForStream(spid).length).toBe(1)
         
         // send empty list and wait for expected events
         await runAndWaitForEvents([
@@ -99,8 +97,8 @@ describe('Check tracker instructions to node', () => {
         ])
 
         // @ts-expect-error private field
-        expect(nodeOne.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(0)
+        expect(nodeOne.streams.getNeighborsForStream(spid).length).toBe(0)
         // @ts-expect-error private field
-        expect(nodeTwo.streams.getNeighborsForStream(streamIdAndPartition).length).toBe(0)
+        expect(nodeTwo.streams.getNeighborsForStream(spid).length).toBe(0)
     })
 })

--- a/packages/network/test/integration/tracker.test.ts
+++ b/packages/network/test/integration/tracker.test.ts
@@ -55,10 +55,10 @@ describe('check tracker, nodes and statuses from nodes', () => {
         // @ts-expect-error private field
         await runAndWaitForEvents(() => {subscriberOne.start()}, [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED])
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-1::0': {
+            'stream-1#0': {
                 subscriberOne: [],
             },
-            'stream-2::2': {
+            'stream-2#2': {
                 subscriberOne: []
             }
         })
@@ -66,11 +66,11 @@ describe('check tracker, nodes and statuses from nodes', () => {
         // @ts-expect-error private field
         await runAndWaitForEvents(()=> { subscriberTwo.start() }, [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED])
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-1::0': {
+            'stream-1#0': {
                 subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
                 subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}]
             },
-            'stream-2::2': {
+            'stream-2#2': {
                 subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
                 subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}]
             }
@@ -92,11 +92,11 @@ describe('check tracker, nodes and statuses from nodes', () => {
         ])
 
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-1::0': {
+            'stream-1#0': {
                 subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
                 subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}],
             },
-            'stream-2::2': {
+            'stream-2#2': {
                 subscriberTwo: []
             }
         })
@@ -108,21 +108,21 @@ describe('check tracker, nodes and statuses from nodes', () => {
         ])
 
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-1::0': {
+            'stream-1#0': {
                 subscriberTwo: [],
             },
-            'stream-2::2': {
+            'stream-2#2': {
                 subscriberTwo: []
             }
         })
 
         await runAndWaitForConditions(
             () => subscriberTwo.unsubscribe('stream-1', 0),
-            () => getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())['stream-1::0'] == null
+            () => getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())['stream-1#0'] == null
         )
 
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
-            'stream-2::2': {
+            'stream-2#2': {
                 subscriberTwo: []
             }
         })

--- a/packages/network/test/integration/unsubscribe-from-stream.test.ts
+++ b/packages/network/test/integration/unsubscribe-from-stream.test.ts
@@ -1,7 +1,7 @@
 import { Tracker } from '../../src/logic/tracker/Tracker'
 import { NetworkNode } from '../../src/logic/node/NetworkNode'
 
-import { MessageLayer } from 'streamr-client-protocol'
+import { MessageLayer, SPIDKey } from 'streamr-client-protocol'
 import { waitForEvent } from 'streamr-test-utils'
 
 import { createNetworkNode, startTracker } from '../../src/composition'
@@ -60,9 +60,9 @@ describe('node unsubscribing from a stream', () => {
     })
 
     test('node still receives data for subscribed streams thru existing connections', async () => {
-        const actual: string[] = []
+        const actual: SPIDKey[] = []
         nodeB.addMessageListener((streamMessage) => {
-            actual.push(`${streamMessage.getStreamId()}::${streamMessage.getStreamPartition()}`)
+            actual.push(`${streamMessage.getStreamId()}#${streamMessage.getStreamPartition()}`)
         })
 
         nodeB.unsubscribe('s', 2)
@@ -77,7 +77,7 @@ describe('node unsubscribing from a stream', () => {
             content: {},
         }))
         await waitForEvent(nodeB, NodeEvent.UNSEEN_MESSAGE_RECEIVED)
-        expect(actual).toEqual(['s::1'])
+        expect(actual).toEqual(['s#1'])
     })
 
     test('connection between nodes is not kept if no shared streams', async () => {

--- a/packages/network/test/unit/InstructionCounter.test.ts
+++ b/packages/network/test/unit/InstructionCounter.test.ts
@@ -11,7 +11,8 @@ describe('InstructionCounter', () => {
     it('if counters have not been set', () => {
         const status: Partial<Status> = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 123
             }
@@ -21,21 +22,23 @@ describe('InstructionCounter', () => {
     })
 
     it('stream specific', () => {
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-1#0')
+        instructionCounter.setOrIncrement('node', 'stream-1#0')
+        instructionCounter.setOrIncrement('node', 'stream-2#0')
+        instructionCounter.setOrIncrement('node', 'stream-2#0')
+        instructionCounter.setOrIncrement('node', 'stream-2#0')
         const status1 = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
-                spidKey: 'stream-2',
+                id: 'stream-2',
+                partition: 0,
                 neighbors: [],
                 counter: 3
             }
@@ -45,21 +48,23 @@ describe('InstructionCounter', () => {
     })
 
     it('node specific', () => {
-        instructionCounter.setOrIncrement('node-1', 'stream-1')
-        instructionCounter.setOrIncrement('node-1', 'stream-1')
-        instructionCounter.setOrIncrement('node-2', 'stream-1')
-        instructionCounter.setOrIncrement('node-2', 'stream-1')
-        instructionCounter.setOrIncrement('node-2', 'stream-1')
+        instructionCounter.setOrIncrement('node-1', 'stream-1#0')
+        instructionCounter.setOrIncrement('node-1', 'stream-1#0')
+        instructionCounter.setOrIncrement('node-2', 'stream-1#0')
+        instructionCounter.setOrIncrement('node-2', 'stream-1#0')
+        instructionCounter.setOrIncrement('node-2', 'stream-1#0')
         const status1 = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 3
             }
@@ -69,13 +74,14 @@ describe('InstructionCounter', () => {
     })
 
     it('removeNode unsets counters', () => {
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1#0')
+        instructionCounter.setOrIncrement('node', 'stream-1#0')
+        instructionCounter.setOrIncrement('node', 'stream-1#0')
         instructionCounter.removeNode('node')
         const status = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 0
             }
@@ -90,7 +96,8 @@ describe('InstructionCounter', () => {
         instructionCounter.removeStream('stream-1')
         const status = {
             stream: {
-                spidKey: 'stream-1',
+                id: 'stream-1',
+                partition: 0,
                 neighbors: [],
                 counter: 0
             }

--- a/packages/network/test/unit/InstructionCounter.test.ts
+++ b/packages/network/test/unit/InstructionCounter.test.ts
@@ -11,7 +11,7 @@ describe('InstructionCounter', () => {
     it('if counters have not been set', () => {
         const status: Partial<Status> = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 123
             }
@@ -28,14 +28,14 @@ describe('InstructionCounter', () => {
         instructionCounter.setOrIncrement('node', 'stream-2')
         const status1 = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
-                streamKey: 'stream-2',
+                spidKey: 'stream-2',
                 neighbors: [],
                 counter: 3
             }
@@ -52,14 +52,14 @@ describe('InstructionCounter', () => {
         instructionCounter.setOrIncrement('node-2', 'stream-1')
         const status1 = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 1
             }
         }
         const status2 = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 3
             }
@@ -75,7 +75,7 @@ describe('InstructionCounter', () => {
         instructionCounter.removeNode('node')
         const status = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 0
             }
@@ -90,7 +90,7 @@ describe('InstructionCounter', () => {
         instructionCounter.removeStream('stream-1')
         const status = {
             stream: {
-                streamKey: 'stream-1',
+                spidKey: 'stream-1',
                 neighbors: [],
                 counter: 0
             }

--- a/packages/network/test/unit/InstructionRetryManager.test.ts
+++ b/packages/network/test/unit/InstructionRetryManager.test.ts
@@ -98,7 +98,7 @@ describe('InstructionRetryManager', () => {
             [createInstruction('stream-2', 2), 'tracker-2', false],
         ])
 
-        instructionRetryManager.removeStream('stream-1::0')
+        instructionRetryManager.removeStream('stream-1#0')
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
             [createInstruction('stream-1', 1), 'tracker-1', false],

--- a/packages/network/test/unit/InstructionSender.test.ts
+++ b/packages/network/test/unit/InstructionSender.test.ts
@@ -1,8 +1,8 @@
+import { SPIDKey } from 'streamr-client-protocol'
 import { Instruction, InstructionSender } from '../../src/logic/tracker/InstructionSender'
-import { StreamKey } from '../../src/identifiers'
 
-const MOCK_STREAM_1 = 'stream-id::1'
-const MOCK_STREAM_2 = 'stream-id::2'
+const MOCK_SPID_1 = 'stream-id#1'
+const MOCK_SPID_2 = 'stream-id#2'
 const STARTUP_TIME = 1234567890
 
 const DEBOUNCE_WAIT = 100
@@ -10,11 +10,11 @@ const MAX_WAIT = 2000
 
 let mockInstructionIdSuffix = 0
 
-const createMockInstruction = (streamKey: StreamKey) => {
+const createMockInstruction = (spidKey: SPIDKey) => {
     mockInstructionIdSuffix++
     return {
         nodeId: `mock-node-id-${mockInstructionIdSuffix}`,
-        streamKey
+        spidKey
     } as any
 }
 
@@ -46,7 +46,7 @@ describe('InstructionSender', () => {
     })
 
     it('wait stabilization', () => {
-        const instruction = createMockInstruction(MOCK_STREAM_1)
+        const instruction = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction)
         expect(send).not.toBeCalled()
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
@@ -55,10 +55,10 @@ describe('InstructionSender', () => {
     })
 
     it('add within stabilization wait', () => {
-        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        const instruction1 = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction1)
         jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
-        const instruction2 = createMockInstruction(MOCK_STREAM_1)
+        const instruction2 = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
         expect(send).toBeCalledTimes(1)
@@ -66,10 +66,10 @@ describe('InstructionSender', () => {
     })
 
     it('add after stabilization wait', () => {
-        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        const instruction1 = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction1)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
-        const instruction2 = createMockInstruction(MOCK_STREAM_1)
+        const instruction2 = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
         expect(send).toBeCalledTimes(2)
@@ -79,7 +79,7 @@ describe('InstructionSender', () => {
     it('max wait reached', () => {
         const expected: Instruction[] = []
         while ((Date.now() - STARTUP_TIME) < MAX_WAIT) {
-            const instruction = createMockInstruction(MOCK_STREAM_1)
+            const instruction = createMockInstruction(MOCK_SPID_1)
             sender.addInstruction(instruction)
             expected.push(instruction)
             jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
@@ -89,10 +89,10 @@ describe('InstructionSender', () => {
     })
 
     it('independent stream buffers', () => {
-        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        const instruction1 = createMockInstruction(MOCK_SPID_1)
         sender.addInstruction(instruction1)
         jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
-        const instruction2 = createMockInstruction(MOCK_STREAM_2)
+        const instruction2 = createMockInstruction(MOCK_SPID_2)
         sender.addInstruction(instruction2)
         jest.advanceTimersByTime(DEBOUNCE_WAIT)
         expect(send).toBeCalledTimes(2)

--- a/packages/network/test/unit/Propagation.test.ts
+++ b/packages/network/test/unit/Propagation.test.ts
@@ -1,7 +1,6 @@
+import { MessageIDStrict, SPID, StreamMessage } from 'streamr-client-protocol'
 import { Propagation } from '../../src/logic/node/propagation/Propagation'
 import { NodeId } from '../../src/logic/node/Node'
-import { StreamIdAndPartition } from '../../src/identifiers'
-import { MessageIDStrict, StreamMessage } from 'streamr-client-protocol'
 import { wait } from 'streamr-test-utils'
 
 function makeMsg(streamId: string, partition: number, ts: number, msgNo: number): StreamMessage {
@@ -16,7 +15,7 @@ function makeMsg(streamId: string, partition: number, ts: number, msgNo: number)
 const TTL = 100
 
 describe(Propagation, () => {
-    let getNeighbors: jest.Mock<ReadonlyArray<NodeId>, [StreamIdAndPartition]>
+    let getNeighbors: jest.Mock<ReadonlyArray<NodeId>, [SPID]>
     let sendToNeighbor: jest.Mock<Promise<unknown>, [string, StreamMessage]>
     let propagation: Propagation
 
@@ -68,47 +67,47 @@ describe(Propagation, () => {
 
         it('sends to new neighbor', () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
-            propagation.onNeighborJoined('n4', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n4', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(1)
             expect(sendToNeighbor).toHaveBeenNthCalledWith(1, 'n4', msg)
         })
 
         it('no-op if passed non-existing stream', () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
-            propagation.onNeighborJoined('n4', new StreamIdAndPartition('non-existing-stream', 0))
+            propagation.onNeighborJoined('n4', new SPID('non-existing-stream', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
 
         it('no-op if passed source node', () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
-            propagation.onNeighborJoined('n2', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n2', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
 
         it('no-op if passed already handled neighbor', () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
-            propagation.onNeighborJoined('n3', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n3', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
 
         it('no-op if initially `minPropagationTargets` were propagated to', () => {
             setUpAndFeed(['n1', 'n2', 'n3', 'n4'])
-            propagation.onNeighborJoined('n5', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n5', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
 
         it('no-op if later `minPropagationTargets` have been propagated to', () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
-            propagation.onNeighborJoined('n4', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n4', new SPID('s1', 0))
             sendToNeighbor.mockClear()
-            propagation.onNeighborJoined('n5', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n5', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
 
         it('no-op if TTL expires', async () => {
             setUpAndFeed(['n1', 'n2', 'n3'])
             await wait(TTL + 1)
-            propagation.onNeighborJoined('n4', new StreamIdAndPartition('s1', 0))
+            propagation.onNeighborJoined('n4', new SPID('s1', 0))
             expect(sendToNeighbor).toHaveBeenCalledTimes(0)
         })
     })

--- a/packages/network/test/unit/PropagationTaskStore.test.ts
+++ b/packages/network/test/unit/PropagationTaskStore.test.ts
@@ -1,11 +1,10 @@
+import { MessageIDStrict, SPID, StreamMessage } from 'streamr-client-protocol'
+import { NodeId } from '../../src/logic/node/Node'
+import { wait } from 'streamr-test-utils'
 import {
     PropagationTaskStore,
     PropagationTask
 } from '../../src/logic/node/propagation/PropagationTaskStore'
-import { MessageIDStrict, StreamMessage } from 'streamr-client-protocol'
-import { NodeId } from '../../src/logic/node/Node'
-import { StreamIdAndPartition } from '../../src/identifiers'
-import { wait } from 'streamr-test-utils'
 
 function makeTask(streamId: string, partition: number, ts: number, neighbors: string[]): PropagationTask {
     // Contents (apart from messageId) not so important here, but generate some for variety
@@ -48,50 +47,50 @@ describe(PropagationTaskStore, () => {
     })
 
     it('get tasks by streamId', () => {
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[0], TASKS[1]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([TASKS[2]])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([TASKS[3]])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([TASKS[4]])
-        expect(store.get(new StreamIdAndPartition('non-existing', 0))).toEqual([])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[0], TASKS[1]])
+        expect(store.get(new SPID('s1', 1))).toEqual([TASKS[2]])
+        expect(store.get(new SPID('s2', 0))).toEqual([TASKS[3]])
+        expect(store.get(new SPID('s3', 0))).toEqual([TASKS[4]])
+        expect(store.get(new SPID('non-existing', 0))).toEqual([])
     })
 
     it('fifo dropping when full', () => {
         store.add(TASKS[5])
         store.add(TASKS[6])
 
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[5]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([TASKS[2], TASKS[6]])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([TASKS[3]])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([TASKS[4]])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[5]])
+        expect(store.get(new SPID('s1', 1))).toEqual([TASKS[2], TASKS[6]])
+        expect(store.get(new SPID('s2', 0))).toEqual([TASKS[3]])
+        expect(store.get(new SPID('s3', 0))).toEqual([TASKS[4]])
 
         store.add(TASKS[7])
         store.add(TASKS[8])
 
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[5]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([TASKS[6]])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([TASKS[4]])
-        expect(store.get(new StreamIdAndPartition('s4', 0))).toEqual([TASKS[7]])
-        expect(store.get(new StreamIdAndPartition('s5', 0))).toEqual([TASKS[8]])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[5]])
+        expect(store.get(new SPID('s1', 1))).toEqual([TASKS[6]])
+        expect(store.get(new SPID('s2', 0))).toEqual([])
+        expect(store.get(new SPID('s3', 0))).toEqual([TASKS[4]])
+        expect(store.get(new SPID('s4', 0))).toEqual([TASKS[7]])
+        expect(store.get(new SPID('s5', 0))).toEqual([TASKS[8]])
 
         store.add(TASKS[9])
 
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[5]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([TASKS[6]])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([TASKS[9]])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([])
-        expect(store.get(new StreamIdAndPartition('s4', 0))).toEqual([TASKS[7]])
-        expect(store.get(new StreamIdAndPartition('s5', 0))).toEqual([TASKS[8]])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[5]])
+        expect(store.get(new SPID('s1', 1))).toEqual([TASKS[6]])
+        expect(store.get(new SPID('s2', 0))).toEqual([TASKS[9]])
+        expect(store.get(new SPID('s3', 0))).toEqual([])
+        expect(store.get(new SPID('s4', 0))).toEqual([TASKS[7]])
+        expect(store.get(new SPID('s5', 0))).toEqual([TASKS[8]])
     })
 
     it('deleting tasks', () => {
         store.delete(TASKS[3].message.messageId)
         store.delete(TASKS[0].message.messageId)
 
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[1]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([TASKS[2]])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([TASKS[4]])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[1]])
+        expect(store.get(new SPID('s1', 1))).toEqual([TASKS[2]])
+        expect(store.get(new SPID('s2', 0))).toEqual([])
+        expect(store.get(new SPID('s3', 0))).toEqual([TASKS[4]])
     })
 
     it('stale tasks are not returned', async () => {
@@ -104,9 +103,9 @@ describe(PropagationTaskStore, () => {
         store.add(TASKS[3])
         store.add(TASKS[4])
         await wait((TTL / 2) + 1)
-        expect(store.get(new StreamIdAndPartition('s1', 0))).toEqual([TASKS[1]])
-        expect(store.get(new StreamIdAndPartition('s1', 1))).toEqual([])
-        expect(store.get(new StreamIdAndPartition('s2', 0))).toEqual([TASKS[3]])
-        expect(store.get(new StreamIdAndPartition('s3', 0))).toEqual([TASKS[4]])
+        expect(store.get(new SPID('s1', 0))).toEqual([TASKS[1]])
+        expect(store.get(new SPID('s1', 1))).toEqual([])
+        expect(store.get(new SPID('s2', 0))).toEqual([TASKS[3]])
+        expect(store.get(new SPID('s3', 0))).toEqual([TASKS[4]])
     })
 })

--- a/packages/network/test/unit/StreamManager.test.ts
+++ b/packages/network/test/unit/StreamManager.test.ts
@@ -12,8 +12,7 @@ describe('StreamManager', () => {
 
     test('starts out empty', () => {
         expect(manager.isSetUp(new SPID('streamId', 0))).toEqual(false)
-        expect(manager.getStreams()).toEqual([])
-        expect(manager.getStreamsAsKeys()).toEqual([])
+        expect(Array.from(manager.getSPIDKeys())).toEqual([])
     })
 
     test('setting up streams and testing values', () => {
@@ -25,12 +24,7 @@ describe('StreamManager', () => {
         expect(manager.isSetUp(new SPID('stream-1', 1))).toEqual(true)
         expect(manager.isSetUp(new SPID('stream-2', 0))).toEqual(true)
 
-        expect(manager.getStreams()).toEqual([
-            new SPID('stream-1', 0),
-            new SPID('stream-1', 1),
-            new SPID('stream-2', 0)
-        ])
-        expect(manager.getStreamsAsKeys()).toEqual(['stream-1#0', 'stream-1#1', 'stream-2#0'])
+        expect(Array.from(manager.getSPIDKeys())).toIncludeSameMembers(['stream-1#0', 'stream-1#1', 'stream-2#0'])
 
         expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toBeEmpty()
         expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toBeEmpty()
@@ -192,9 +186,7 @@ describe('StreamManager', () => {
 
         expect(manager.isSetUp(new SPID('stream-1', 0))).toEqual(false)
 
-        expect(manager.getStreams()).toEqual([
-            new SPID('stream-2', 0)
-        ])
+        expect(Array.from(manager.getSPIDKeys())).toEqual(['stream-2#0'])
     })
 
     test('updating counter', () => {

--- a/packages/network/test/unit/StreamManager.test.ts
+++ b/packages/network/test/unit/StreamManager.test.ts
@@ -1,7 +1,5 @@
-import { MessageLayer } from 'streamr-client-protocol'
-
+import { MessageLayer, SPID } from 'streamr-client-protocol'
 import { StreamManager } from '../../src/logic/node/StreamManager'
-import { StreamIdAndPartition } from '../../src/identifiers'
 
 const { MessageID, MessageRef } = MessageLayer
 
@@ -13,42 +11,42 @@ describe('StreamManager', () => {
     })
 
     test('starts out empty', () => {
-        expect(manager.isSetUp(new StreamIdAndPartition('streamId', 0))).toEqual(false)
+        expect(manager.isSetUp(new SPID('streamId', 0))).toEqual(false)
         expect(manager.getStreams()).toEqual([])
         expect(manager.getStreamsAsKeys()).toEqual([])
     })
 
     test('setting up streams and testing values', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
-        manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 1))
+        manager.setUpStream(new SPID('stream-1', 0))
+        manager.setUpStream(new SPID('stream-2', 0))
+        manager.setUpStream(new SPID('stream-1', 1))
 
-        expect(manager.isSetUp(new StreamIdAndPartition('stream-1', 0))).toEqual(true)
-        expect(manager.isSetUp(new StreamIdAndPartition('stream-1', 1))).toEqual(true)
-        expect(manager.isSetUp(new StreamIdAndPartition('stream-2', 0))).toEqual(true)
+        expect(manager.isSetUp(new SPID('stream-1', 0))).toEqual(true)
+        expect(manager.isSetUp(new SPID('stream-1', 1))).toEqual(true)
+        expect(manager.isSetUp(new SPID('stream-2', 0))).toEqual(true)
 
         expect(manager.getStreams()).toEqual([
-            new StreamIdAndPartition('stream-1', 0),
-            new StreamIdAndPartition('stream-1', 1),
-            new StreamIdAndPartition('stream-2', 0)
+            new SPID('stream-1', 0),
+            new SPID('stream-1', 1),
+            new SPID('stream-2', 0)
         ])
-        expect(manager.getStreamsAsKeys()).toEqual(['stream-1::0', 'stream-1::1', 'stream-2::0'])
+        expect(manager.getStreamsAsKeys()).toEqual(['stream-1#0', 'stream-1#1', 'stream-2#0'])
 
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toBeEmpty()
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toBeEmpty()
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new SPID('stream-2', 0))).toBeEmpty()
     })
 
     test('cannot re-setup same stream', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-id', 0))
+        manager.setUpStream(new SPID('stream-id', 0))
 
         expect(() => {
-            manager.setUpStream(new StreamIdAndPartition('stream-id', 0))
-        }).toThrowError('Stream stream-id::0 already set up')
+            manager.setUpStream(new SPID('stream-id', 0))
+        }).toThrowError('Stream stream-id#0 already set up')
     })
 
     test('can duplicate detect on previously set up stream', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-id', 0))
+        manager.setUpStream(new SPID('stream-id', 0))
 
         expect(() => {
             manager.markNumbersAndCheckThatIsNotDuplicate(
@@ -64,11 +62,11 @@ describe('StreamManager', () => {
                 new MessageID('stream-id', 0, 10, 0, 'publisher-id', 'session-id'),
                 new MessageRef(5, 0)
             )
-        }).toThrowError('Stream stream-id::0 is not set up')
+        }).toThrowError('Stream stream-id#0 is not set up')
     })
 
     test('duplicate detection is per publisher, msgChainId', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-id', 0))
+        manager.setUpStream(new SPID('stream-id', 0))
         manager.markNumbersAndCheckThatIsNotDuplicate(
             new MessageID('stream-id', 0, 10, 0, 'publisher-1', 'session-1'),
             new MessageRef(5, 0)
@@ -96,14 +94,14 @@ describe('StreamManager', () => {
     })
 
     test('adding neighbor nodes to a set-up stream', () => {
-        const streamId = new StreamIdAndPartition('stream-id', 0)
-        const streamId2 = new StreamIdAndPartition('stream-id-2', 0)
+        const streamId = new SPID('stream-id', 0)
+        const streamId2 = new SPID('stream-id-2', 0)
 
-        manager.setUpStream(new StreamIdAndPartition('stream-id', 0))
+        manager.setUpStream(new SPID('stream-id', 0))
         manager.addNeighbor(streamId, 'node-1')
         manager.addNeighbor(streamId, 'node-2')
 
-        manager.setUpStream(new StreamIdAndPartition('stream-id-2', 0))
+        manager.setUpStream(new SPID('stream-id-2', 0))
         manager.addNeighbor(streamId2, 'node-1')
         manager.addNeighbor(streamId2, 'node-2')
         manager.addNeighbor(streamId2, 'node-3')
@@ -122,8 +120,8 @@ describe('StreamManager', () => {
     })
 
     test('removing node from stream removes it from neighbors', () => {
-        const streamId = new StreamIdAndPartition('stream-id', 0)
-        const streamId2 = new StreamIdAndPartition('stream-id-2', 0)
+        const streamId = new SPID('stream-id', 0)
+        const streamId2 = new SPID('stream-id-2', 0)
 
         manager.setUpStream(streamId)
         manager.addNeighbor(streamId, 'node-1')
@@ -156,54 +154,54 @@ describe('StreamManager', () => {
     })
 
     test('remove node from all streams', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 1))
-        manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
+        manager.setUpStream(new SPID('stream-1', 0))
+        manager.setUpStream(new SPID('stream-1', 1))
+        manager.setUpStream(new SPID('stream-2', 0))
 
-        manager.addNeighbor(new StreamIdAndPartition('stream-1', 0), 'node')
-        manager.addNeighbor(new StreamIdAndPartition('stream-1', 0), 'should-not-be-removed')
+        manager.addNeighbor(new SPID('stream-1', 0), 'node')
+        manager.addNeighbor(new SPID('stream-1', 0), 'should-not-be-removed')
 
-        manager.addNeighbor(new StreamIdAndPartition('stream-1', 1), 'node')
-        manager.addNeighbor(new StreamIdAndPartition('stream-1', 1), 'should-not-be-removed')
+        manager.addNeighbor(new SPID('stream-1', 1), 'node')
+        manager.addNeighbor(new SPID('stream-1', 1), 'should-not-be-removed')
 
-        manager.addNeighbor(new StreamIdAndPartition('stream-2', 0), 'node')
-        manager.addNeighbor(new StreamIdAndPartition('stream-2', 0), 'should-not-be-removed')
+        manager.addNeighbor(new SPID('stream-2', 0), 'node')
+        manager.addNeighbor(new SPID('stream-2', 0), 'should-not-be-removed')
 
         manager.removeNodeFromAllStreams('node')
 
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 0))).toIncludeSameMembers(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-1', 1))).toIncludeSameMembers(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new StreamIdAndPartition('stream-2', 0))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-2', 0))).toIncludeSameMembers(['should-not-be-removed'])
 
-        expect(manager.hasNeighbor(new StreamIdAndPartition('stream-1', 0), 'node')).toEqual(false)
-        expect(manager.hasNeighbor(new StreamIdAndPartition('stream-2', 0), 'node')).toEqual(false)
+        expect(manager.hasNeighbor(new SPID('stream-1', 0), 'node')).toEqual(false)
+        expect(manager.hasNeighbor(new SPID('stream-2', 0), 'node')).toEqual(false)
 
         expect(manager.isNodePresent('should-not-be-removed')).toEqual(true)
         expect(manager.isNodePresent('node')).toEqual(false)
     })
 
     test('remove stream', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
-        manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
+        manager.setUpStream(new SPID('stream-1', 0))
+        manager.setUpStream(new SPID('stream-2', 0))
 
-        manager.addNeighbor(new StreamIdAndPartition('stream-1', 0), 'n1')
+        manager.addNeighbor(new SPID('stream-1', 0), 'n1')
 
-        manager.addNeighbor(new StreamIdAndPartition('stream-2', 0), 'n1')
+        manager.addNeighbor(new SPID('stream-2', 0), 'n1')
 
-        manager.removeStream(new StreamIdAndPartition('stream-1', 0))
+        manager.removeStream(new SPID('stream-1', 0))
 
-        expect(manager.isSetUp(new StreamIdAndPartition('stream-1', 0))).toEqual(false)
+        expect(manager.isSetUp(new SPID('stream-1', 0))).toEqual(false)
 
         expect(manager.getStreams()).toEqual([
-            new StreamIdAndPartition('stream-2', 0)
+            new SPID('stream-2', 0)
         ])
     })
 
     test('updating counter', () => {
-        manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
-        manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
+        manager.setUpStream(new SPID('stream-1', 0))
+        manager.setUpStream(new SPID('stream-2', 0))
 
-        manager.updateCounter(new StreamIdAndPartition('stream-1', 0), 50)
-        manager.updateCounter(new StreamIdAndPartition('stream-2', 0), 100)
+        manager.updateCounter(new SPID('stream-1', 0), 50)
+        manager.updateCounter(new SPID('stream-2', 0), 100)
     })
 })

--- a/packages/network/test/unit/TrackerConnector.test.ts
+++ b/packages/network/test/unit/TrackerConnector.test.ts
@@ -29,10 +29,10 @@ const TRACKERS = [
     },
 ]
 
-const T1_STREAM = new SPID('streamOne', 0)
-const T2_STREAM = new SPID('streamOne', 15)
-const T3_STREAM = new SPID('streamSix', 0)
-const T4_STREAM = new SPID('streamTwo', 0)
+const T1_STREAM = SPID.from('a#0')
+const T2_STREAM = SPID.from('b#10')
+const T3_STREAM = SPID.from('c#12')
+const T4_STREAM = SPID.from('d#4')
 
 describe(TrackerConnector, () => {
     let streams: Array<SPID>
@@ -42,8 +42,8 @@ describe(TrackerConnector, () => {
     beforeAll(() => {
         // sanity check stream hash assignments
         const trackerRegistry = new Utils.TrackerRegistry<TrackerInfo>(TRACKERS)
-        function checkTrackerAssignment({ streamId, streamPartition }: SPID, expectedTracker: TrackerInfo): void {
-            expect(trackerRegistry.getTracker(streamId, streamPartition)).toEqual(expectedTracker)
+        function checkTrackerAssignment(spid: SPID, expectedTracker: TrackerInfo): void {
+            expect(trackerRegistry.getTracker(spid)).toEqual(expectedTracker)
         }
         checkTrackerAssignment(T1_STREAM, TRACKERS[0])
         checkTrackerAssignment(T2_STREAM, TRACKERS[1])

--- a/packages/network/test/unit/TrackerConnector.test.ts
+++ b/packages/network/test/unit/TrackerConnector.test.ts
@@ -1,8 +1,8 @@
-import { Utils } from 'streamr-client-protocol'
-import { TrackerConnector } from '../../src/logic/node/TrackerConnector'
-import { StreamIdAndPartition, TrackerInfo } from '../../src/identifiers'
-import { TrackerId } from '../../src/logic/tracker/Tracker'
 import { wait } from 'streamr-test-utils'
+import { SPID, Utils } from 'streamr-client-protocol'
+import { TrackerConnector } from '../../src/logic/node/TrackerConnector'
+import { TrackerInfo } from '../../src/identifiers'
+import { TrackerId } from '../../src/logic/tracker/Tracker'
 
 const TTL_IN_MS = 10
 
@@ -29,21 +29,21 @@ const TRACKERS = [
     },
 ]
 
-const T1_STREAM = new StreamIdAndPartition('streamOne', 0)
-const T2_STREAM = new StreamIdAndPartition('streamOne', 15)
-const T3_STREAM = new StreamIdAndPartition('streamSix', 0)
-const T4_STREAM = new StreamIdAndPartition('streamTwo', 0)
+const T1_STREAM = new SPID('streamOne', 0)
+const T2_STREAM = new SPID('streamOne', 15)
+const T3_STREAM = new SPID('streamSix', 0)
+const T4_STREAM = new SPID('streamTwo', 0)
 
 describe(TrackerConnector, () => {
-    let streams: Array<StreamIdAndPartition>
+    let streams: Array<SPID>
     let activeConnections: Set<TrackerId>
     let connector: TrackerConnector
 
     beforeAll(() => {
         // sanity check stream hash assignments
         const trackerRegistry = new Utils.TrackerRegistry<TrackerInfo>(TRACKERS)
-        function checkTrackerAssignment({ id, partition }: StreamIdAndPartition, expectedTracker: TrackerInfo): void {
-            expect(trackerRegistry.getTracker(id, partition)).toEqual(expectedTracker)
+        function checkTrackerAssignment({ streamId, streamPartition }: SPID, expectedTracker: TrackerInfo): void {
+            expect(trackerRegistry.getTracker(streamId, streamPartition)).toEqual(expectedTracker)
         }
         checkTrackerAssignment(T1_STREAM, TRACKERS[0])
         checkTrackerAssignment(T2_STREAM, TRACKERS[1])

--- a/packages/network/test/unit/deprecated-tracker-status.test.ts
+++ b/packages/network/test/unit/deprecated-tracker-status.test.ts
@@ -1,0 +1,85 @@
+import { Tracker } from '../../src/logic/tracker/Tracker'
+import { TrackerServer, Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
+
+const SOURCE_NODE = 'source-node'
+const TARGET_NODE_1 = 'target-node-1'
+const TARGET_NODE_2 = 'target-node-2'
+const STREAM_SPID_KEY = 's1#0'
+const STREAM_KEY = 's1::0'
+const COUNTER = 123
+
+describe('Tracker reads deprecated status format', () => {
+
+    let trackerServer: TrackerServer
+    let createTopology: any
+    let updateNodeOnStream: any
+    let formAndSendInstructions: any
+
+    beforeAll(() => {
+        trackerServer = new TrackerServer({
+            on: jest.fn(),
+            resolveAddress: jest.fn()
+        } as any)
+        const tracker = new Tracker({
+            maxNeighborsPerNode: 999,
+            protocols: {
+                trackerServer
+            }
+        } as any)
+        createTopology = jest.spyOn(tracker as any, 'createTopology').mockImplementation()
+        updateNodeOnStream = jest.spyOn(tracker as any, 'updateNodeOnStream').mockImplementation()
+        formAndSendInstructions = jest.spyOn(tracker as any, 'formAndSendInstructions').mockImplementation()
+    })
+
+    const assertStatusProcessed = () => {
+        expect(createTopology).toBeCalledTimes(1)
+        expect(createTopology).toBeCalledWith(STREAM_SPID_KEY)
+        expect(updateNodeOnStream).toBeCalledTimes(1)
+        expect(updateNodeOnStream.mock.calls[0][0]).toBe(SOURCE_NODE)
+        const actualStatus = updateNodeOnStream.mock.calls[0][1]
+        expect(actualStatus).toContainEntries([
+            ['counter', COUNTER],
+            ['neighbors', [TARGET_NODE_1, TARGET_NODE_2]],
+            ['spidKey', STREAM_SPID_KEY]
+        ])
+        expect(formAndSendInstructions).toBeCalledTimes(1)
+        expect(formAndSendInstructions).toBeCalledWith(SOURCE_NODE, STREAM_SPID_KEY)
+    }
+
+    it('multiple streams format', () => {
+        const status: any = {
+            streams: {
+                [STREAM_KEY]: {
+                    inboundNodes: [TARGET_NODE_1, TARGET_NODE_2],
+                    counter: COUNTER
+                }
+            }
+        }
+        trackerServer.emit(TrackerServerEvent.NODE_STATUS_RECEIVED, { status }, SOURCE_NODE)
+        assertStatusProcessed()
+    })
+
+    it('single stream format', () => {
+        const status: any = {
+            stream: {
+                streamKey: STREAM_KEY,
+                inboundNodes: [TARGET_NODE_1, TARGET_NODE_2],
+                counter: COUNTER
+            }
+        }
+        trackerServer.emit(TrackerServerEvent.NODE_STATUS_RECEIVED, { status }, SOURCE_NODE)
+        assertStatusProcessed()
+    })
+
+    it('neighbor format', () => {
+        const status: any = {
+            stream: {
+                streamKey: STREAM_KEY,
+                neighbors: [TARGET_NODE_1, TARGET_NODE_2],
+                counter: COUNTER
+            }
+        }
+        trackerServer.emit(TrackerServerEvent.NODE_STATUS_RECEIVED, { status }, SOURCE_NODE)
+        assertStatusProcessed()
+    })
+})

--- a/packages/network/test/unit/deprecated-tracker-status.test.ts
+++ b/packages/network/test/unit/deprecated-tracker-status.test.ts
@@ -34,7 +34,7 @@ describe('Tracker reads deprecated status format', () => {
     })
 
     const assertStatusProcessed = () => {
-        const spidKey = new SPID(STREAM_ID, STREAM_PARTITION).toKey()
+        const spidKey = SPID.toKey(STREAM_ID, STREAM_PARTITION)
         expect(createTopology).toBeCalledTimes(1)
         expect(createTopology).toBeCalledWith(spidKey)
         expect(updateNodeOnStream).toBeCalledTimes(1)

--- a/packages/network/test/unit/deprecated-tracker-status.test.ts
+++ b/packages/network/test/unit/deprecated-tracker-status.test.ts
@@ -1,11 +1,13 @@
+import { SPID } from 'streamr-client-protocol'
 import { Tracker } from '../../src/logic/tracker/Tracker'
 import { TrackerServer, Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 
 const SOURCE_NODE = 'source-node'
 const TARGET_NODE_1 = 'target-node-1'
 const TARGET_NODE_2 = 'target-node-2'
-const STREAM_SPID_KEY = 's1#0'
-const STREAM_KEY = 's1::0'
+const STREAM_ID = 's1'
+const STREAM_PARTITION = 0
+const STREAM_KEY = `${STREAM_ID}::${STREAM_PARTITION}`
 const COUNTER = 123
 
 describe('Tracker reads deprecated status format', () => {
@@ -32,18 +34,20 @@ describe('Tracker reads deprecated status format', () => {
     })
 
     const assertStatusProcessed = () => {
+        const spidKey = new SPID(STREAM_ID, STREAM_PARTITION).toKey()
         expect(createTopology).toBeCalledTimes(1)
-        expect(createTopology).toBeCalledWith(STREAM_SPID_KEY)
+        expect(createTopology).toBeCalledWith(spidKey)
         expect(updateNodeOnStream).toBeCalledTimes(1)
         expect(updateNodeOnStream.mock.calls[0][0]).toBe(SOURCE_NODE)
         const actualStatus = updateNodeOnStream.mock.calls[0][1]
         expect(actualStatus).toContainEntries([
-            ['counter', COUNTER],
+            ['id', STREAM_ID],
+            ['partition', STREAM_PARTITION],
             ['neighbors', [TARGET_NODE_1, TARGET_NODE_2]],
-            ['spidKey', STREAM_SPID_KEY]
+            ['counter', COUNTER],
         ])
         expect(formAndSendInstructions).toBeCalledTimes(1)
-        expect(formAndSendInstructions).toBeCalledWith(SOURCE_NODE, STREAM_SPID_KEY)
+        expect(formAndSendInstructions).toBeCalledWith(SOURCE_NODE, spidKey)
     }
 
     it('multiple streams format', () => {

--- a/packages/network/test/unit/trackerSummaryUtils.test.ts
+++ b/packages/network/test/unit/trackerSummaryUtils.test.ts
@@ -16,17 +16,17 @@ const createOverlayTopology = (mapping: { [key: string]: string[] }) => {
 test('getNodeConnections', () => {
     const nodes = ['node1', 'node2', 'node3', 'node4', 'node5', 'node6', 'nodeNotInTopology']
     const overlayPerStream = {
-        'stream-a::0': createOverlayTopology({
+        'stream-a#0': createOverlayTopology({
             node1: ['node2', 'node3']
         }),
-        'stream-b::0': createOverlayTopology({
+        'stream-b#0': createOverlayTopology({
             node2: ['node4']
         }),
-        'stream-c::0': createOverlayTopology({}),
-        'stream-d::0': createOverlayTopology({
+        'stream-c#0': createOverlayTopology({}),
+        'stream-d#0': createOverlayTopology({
             node1: ['node3', 'node5']
         }),
-        'stream-e::0': createOverlayTopology({
+        'stream-e#0': createOverlayTopology({
             node6: []
         })
     }

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -1,6 +1,8 @@
-import { MetricsContext } from '../src/composition'
+import { SPIDKey } from 'streamr-client-protocol'
+import { MetricsContext, Tracker } from '../src/composition'
 import { PeerInfo } from '../src/connection/PeerInfo'
 import { ServerWsEndpoint, startHttpServer } from '../src/connection/ws/ServerWsEndpoint'
+import { Node } from '../src/logic/node/Node'
 
 export const startServerWsEndpoint = async (
     host: string,
@@ -15,4 +17,8 @@ export const startServerWsEndpoint = async (
     }
     const httpServer = await startHttpServer(listen, undefined, undefined)
     return  new ServerWsEndpoint(listen, false, httpServer, peerInfo, metricsContext, pingInterval)
+}
+
+export const getSPIDKeys = (nodeOrTracker: Node|Tracker): SPIDKey[] => {
+    return Array.from(nodeOrTracker.getSPIDs(), (spid) => spid.toKey())
 }

--- a/packages/protocol/src/protocol/tracker_layer/instruction_message/InstructionMessage.ts
+++ b/packages/protocol/src/protocol/tracker_layer/instruction_message/InstructionMessage.ts
@@ -4,6 +4,7 @@ import {
     validateIsArray
 } from '../../../utils/validations'
 import TrackerMessage, { TrackerMessageOptions } from '../TrackerMessage'
+import { SPID } from '../../../utils/SPID'
 
 export interface Options extends TrackerMessageOptions {
     streamId: string
@@ -31,5 +32,9 @@ export default class InstructionMessage extends TrackerMessage {
         this.streamPartition = streamPartition
         this.nodeIds = nodeIds
         this.counter = counter
+    }
+
+    getSPID(): SPID {
+        return SPID.from(this)
     }
 }

--- a/packages/protocol/src/utils/SPID.ts
+++ b/packages/protocol/src/utils/SPID.ts
@@ -244,8 +244,14 @@ export class SPID implements SPIDKeyShape {
      * const key = SPID.toKey({ streamId, streamPartition })
      * ```
      */
-    static toKey(spidLike: SPIDLike): SPIDKey {
-        return SPID.from(spidLike).key
+    static toKey(spidLike: SPIDShape): SPIDKey
+    static toKey(streamId: string, streamPartition: number): SPIDKey
+    static toKey(param1: string|SPIDShape, param2?: number): SPIDKey {
+        if ((typeof param1 === 'string') && (param2 !== undefined)) {
+            return new SPID(param1, param2).key
+        } else {
+            return SPID.from(param1).key
+        }
     }
 }
 

--- a/packages/protocol/src/utils/SPID.ts
+++ b/packages/protocol/src/utils/SPID.ts
@@ -244,9 +244,9 @@ export class SPID implements SPIDKeyShape {
      * const key = SPID.toKey({ streamId, streamPartition })
      * ```
      */
-    static toKey(spidLike: SPIDShape): SPIDKey
+    static toKey(spidLike: SPIDLike): SPIDKey
     static toKey(streamId: string, streamPartition: number): SPIDKey
-    static toKey(param1: string|SPIDShape, param2?: number): SPIDKey {
+    static toKey(param1: string|SPIDLike, param2?: number): SPIDKey {
         if ((typeof param1 === 'string') && (param2 !== undefined)) {
             return new SPID(param1, param2).key
         } else {

--- a/packages/protocol/src/utils/SPID.ts
+++ b/packages/protocol/src/utils/SPID.ts
@@ -13,6 +13,8 @@ import ValidationError from '../errors/ValidationError'
 
 type RequiredKeys<T, Keys extends keyof T> = Omit<T, Keys> & Required<Pick<T, Keys>>
 
+export type SPIDKey = string
+
 /**
  * Has both streamId & partition
  */
@@ -22,7 +24,7 @@ export type SPIDShape = {
 }
 
 export type SPIDKeyShape = SPIDShape & {
-    key: string
+    key: SPIDKey
 }
 
 /**
@@ -30,7 +32,7 @@ export type SPIDKeyShape = SPIDShape & {
  * Object cases can be typechecked
  * TODO: SPID string type safety
  */
-export type SPIDLike = string | SPIDShape
+export type SPIDLike = SPIDKey | SPIDShape
 
 /**
  * Must have something that looks like an id.
@@ -70,7 +72,7 @@ export class SPID implements SPIDKeyShape {
     protected static readonly SEPARATOR = '#'
 
     /** string key representing SPID */
-    public readonly key: string
+    public readonly key: SPIDKey
 
     /**
      * @param id - stream id
@@ -224,14 +226,14 @@ export class SPID implements SPIDKeyShape {
     /**
      * String representation of SPID id + partition
      */
-    toString(): string {
+    toString(): SPIDKey {
         return this.key
     }
 
     /**
      * Alias of toString.
      */
-    toKey(): string {
+    toKey(): SPIDKey {
         return this.toString()
     }
 
@@ -242,7 +244,7 @@ export class SPID implements SPIDKeyShape {
      * const key = SPID.toKey({ streamId, streamPartition })
      * ```
      */
-    static toKey(spidLike: SPIDLike): string {
+    static toKey(spidLike: SPIDLike): SPIDKey {
         return SPID.from(spidLike).key
     }
 }

--- a/packages/protocol/src/utils/TrackerRegistry.ts
+++ b/packages/protocol/src/utils/TrackerRegistry.ts
@@ -4,6 +4,7 @@ import { ConnectionInfo } from 'ethers/lib/utils'
 import { keyToArrayIndex } from './HashUtil'
 
 import * as trackerRegistryConfig from '../../contracts/TrackerRegistry.json'
+import { SPID } from './SPID'
 
 const { JsonRpcProvider } = providers
 
@@ -23,17 +24,8 @@ export class TrackerRegistry<T extends TrackerInfo> {
         this.records.sort()  // TODO does this actually sort anything?
     }
 
-    getTracker(streamId: string, partition = 0): T {
-        if (typeof streamId !== 'string' || streamId.indexOf('::') >= 0) {
-            throw new Error(`invalid id: ${streamId}`)
-        }
-        if (!Number.isInteger(partition) || partition < 0) {
-            throw new Error(`invalid partition: ${partition}`)
-        }
-
-        const streamKey = `${streamId}::${partition}`
-
-        const index = keyToArrayIndex(this.records.length, streamKey)
+    getTracker(spid: SPID): T {
+        const index = keyToArrayIndex(this.records.length, spid.toKey())
         return this.records[index]
     }
 

--- a/packages/protocol/test/integration/TrackerRegistry.test.ts
+++ b/packages/protocol/test/integration/TrackerRegistry.test.ts
@@ -1,3 +1,4 @@
+import { SPID } from '../../src/utils/SPID'
 import { createTrackerRegistry, getTrackerRegistryFromContract } from '../../src/utils/TrackerRegistry'
 
 const contractAddress = '0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF'
@@ -55,60 +56,25 @@ describe('TrackerRegistry', () => {
     })
 
     describe('getTracker', () => {
-        test('throws if stream id is invalid', async () => {
+        test('get tracker by SPID', async () => {
             const trackerRegistry = await getTrackerRegistryFromContract({
                 contractAddress, jsonRpcProvider
             })
 
-            // old format
-            expect(() => {
-                trackerRegistry.getTracker('stream-1::0')
-            }).toThrow()
-
-            // stream id is not a string
-            expect(() => {
-                trackerRegistry.getTracker(1234 as any)
-            }).toThrow()
-
-            // partition is not valid
-            expect(() => {
-                trackerRegistry.getTracker('stream-1', '0' as any)
-            }).toThrow()
-
-            expect(() => {
-                trackerRegistry.getTracker('stream-1', -23)
-            }).toThrow()
-
-            // valid id
-            expect(() => {
-                trackerRegistry.getTracker('stream-1')
-            }).not.toThrow()
-
-            expect(() => {
-                trackerRegistry.getTracker('stream-1', 5)
-            }).not.toThrow()
-        })
-
-        test('get tracker by stream key', async () => {
-            const trackerRegistry = await getTrackerRegistryFromContract({
-                contractAddress, jsonRpcProvider
-            })
-
-            // 1->1, 2->2, 3->3 coincidence
-            expect(trackerRegistry.getTracker('stream-1')).toEqual({
+            expect(trackerRegistry.getTracker(SPID.from('a#3'))).toEqual({
                 id: '0xb9e7cEBF7b03AE26458E32a059488386b05798e8',
                 http: 'http://10.200.10.1:30301',
                 ws: 'ws://10.200.10.1:30301'
             })
-            expect(trackerRegistry.getTracker('stream-2')).toEqual({
-                id: '0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2',
-                http: 'http://10.200.10.1:30303',
-                ws: 'ws://10.200.10.1:30303'
-            })
-            expect(trackerRegistry.getTracker('stream-3')).toEqual({
+            expect(trackerRegistry.getTracker(SPID.from('b#1'))).toEqual({
                 id: '0x0540A3e144cdD81F402e7772C76a5808B71d2d30',
                 http: 'http://10.200.10.1:30302',
                 ws: 'ws://10.200.10.1:30302'
+            })
+            expect(trackerRegistry.getTracker(SPID.from('c#7'))).toEqual({
+                id: '0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2',
+                http: 'http://10.200.10.1:30303',
+                ws: 'ws://10.200.10.1:30303'
             })
         })
     })


### PR DESCRIPTION
Use `SPID` and `SPIDKey` to identify and a stream partition. Removed deprecated classes/types: `StreamdIdAndPartition`, `StreamKey` and `StreamPart`.

Most changes are modifications to internal data structures.  

External modifications: 

1. Status message format changed from `{ streamKey: '0x123::0, ...' }` to `{ id: '0x123', partition: 0 ... }`. There is a temporary backwards compatibility handler so that Tracker can read the deprecated format.
2. The data format of Tracker's HTTP endpoints changed. The keys are now `SPIDKeys`, not `StreamKeys`.
3. The public accessor method in in `Node.ts` and `Tracker.ts` changed from getStreams() to getSPIDs(). The return value changed from `string` array to Iterable<SPID>.

How SPID is used in this PR:

1. `SPID` is an independent entity, and a preferred way to reference to a stream partition. When we add a stream partition e.g. to a storage config, we use method `addSPID()` (not `getStreams()` or `getStreamPartitions()`). 
2. `SPIDKey` is an internal data format. The public methods of the application (in `Node.ts` and `Tracker.ts`) return `SPIDs`, not `SPIDKeys`. If we need to use textual representation of a SPID (e.g. as a JSON key, or as a parameter in command line), we read and write data in `SPIDKey` format.
3. We don't yet have public API methods which take `SPIDs` as input parameters. Maybe we could allow both: `SPID|SPIDKey`? 
4. In protocol level (the status message), we don't use `SPID` or `SPIDKey`. The format is plain `{ id, partition }`. 
5. In log files we don't use terms `SPID` or `SPIDKey`. There we use the term "partition": e.g.`"Add 123 partitions to storage config"`.

The internal hashing in `TrackerRegistry` are calculated from `SPIDKey` values. Therefore `streamId` -> `trackerIndex` results will be different after this change.