### PR TITLE
fix(protocol, network): backwards compatible hashing

### DIFF
--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -9,13 +9,13 @@ import { Event as NodeEvent } from '../../src/logic/node/Node'
 import { getSPIDKeys } from '../utils'
 
 // TODO: maybe worth re-designing this in a way that isn't this arbitrary?
-const FIRST_STREAM = 'a-0' // assigned to trackerOne (arbitrarily by hashing algo)
-const SECOND_STREAM = 'b-8' // assigned to trackerTwo
-const THIRD_STREAM = 'c-2' // assigned to trackerThree
+const FIRST_STREAM = 'stream-1' // assigned to trackerOne (arbitrarily by hashing algo)
+const SECOND_STREAM = 'stream-3' // assigned to trackerTwo
+const THIRD_STREAM = 'stream-2' // assigned to trackerThree
 
-const FIRST_STREAM_2 = 'e-1' // assigned to trackerOne
-const SECOND_STREAM_2 = 'f-3' // assigned to trackerTwo
-const THIRD_STREAM_2 = 'g-0' // assigned to trackerThree
+const FIRST_STREAM_2 = 'stream-13' // assigned to trackerOne
+const SECOND_STREAM_2 = 'stream-10' // assigned to trackerTwo
+const THIRD_STREAM_2 = 'stream-15' // assigned to trackerThree
 
 // Leave out WebRTC related events
 const TRACKER_NODE_EVENTS_OF_INTEREST = [

--- a/packages/network/test/unit/TrackerConnector.test.ts
+++ b/packages/network/test/unit/TrackerConnector.test.ts
@@ -29,10 +29,10 @@ const TRACKERS = [
     },
 ]
 
-const T1_STREAM = SPID.from('a#0')
-const T2_STREAM = SPID.from('b#10')
-const T3_STREAM = SPID.from('c#12')
-const T4_STREAM = SPID.from('d#4')
+const T1_STREAM = SPID.from('streamOne#0')
+const T2_STREAM = SPID.from('streamOne#15')
+const T3_STREAM = SPID.from('streamSix#0')
+const T4_STREAM = SPID.from('streamTwo#0')
 
 describe(TrackerConnector, () => {
     let streams: Array<SPID>

--- a/packages/protocol/src/utils/TrackerRegistry.ts
+++ b/packages/protocol/src/utils/TrackerRegistry.ts
@@ -25,7 +25,8 @@ export class TrackerRegistry<T extends TrackerInfo> {
     }
 
     getTracker(spid: SPID): T {
-        const index = keyToArrayIndex(this.records.length, spid.toKey())
+        const key = spid.toKey().replace('#', '::') // TODO temporary backwards compatibility
+        const index = keyToArrayIndex(this.records.length, key)
         return this.records[index]
     }
 

--- a/packages/protocol/test/integration/TrackerRegistry.test.ts
+++ b/packages/protocol/test/integration/TrackerRegistry.test.ts
@@ -61,17 +61,17 @@ describe('TrackerRegistry', () => {
                 contractAddress, jsonRpcProvider
             })
 
-            expect(trackerRegistry.getTracker(SPID.from('a#3'))).toEqual({
+            expect(trackerRegistry.getTracker(SPID.from('stream-1#0'))).toEqual({
                 id: '0xb9e7cEBF7b03AE26458E32a059488386b05798e8',
                 http: 'http://10.200.10.1:30301',
                 ws: 'ws://10.200.10.1:30301'
             })
-            expect(trackerRegistry.getTracker(SPID.from('b#1'))).toEqual({
+            expect(trackerRegistry.getTracker(SPID.from('stream-3#0'))).toEqual({
                 id: '0x0540A3e144cdD81F402e7772C76a5808B71d2d30',
                 http: 'http://10.200.10.1:30302',
                 ws: 'ws://10.200.10.1:30302'
             })
-            expect(trackerRegistry.getTracker(SPID.from('c#7'))).toEqual({
+            expect(trackerRegistry.getTracker(SPID.from('stream-2#0'))).toEqual({
                 id: '0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2',
                 http: 'http://10.200.10.1:30303',
                 ws: 'ws://10.200.10.1:30303'


### PR DESCRIPTION
This should be reverted later on.

Make tracker hashing algorithm still use `::` as separator for backwards compatibility so a tracker deployment can be made.