### PR TITLE
Replace styfle/cancel-workflow-action with GitHub Actions concurrency

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -13,20 +13,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: broker-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/broker
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -19,20 +19,15 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: client-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/client
 # Be sure to update both workflow files if you edit any env or trigger config
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
   build:
     name: Build using Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/client-code.yml
+++ b/.github/workflows/client-code.yml
@@ -19,20 +19,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: client-code-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/client
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
   lint:
     name: Run linter using Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/client-dataunions.yml
+++ b/.github/workflows/client-dataunions.yml
@@ -19,20 +19,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: client-dataunions-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/client
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
   data-unions-integration:
     name: ${{ matrix.test-name }} ${{ matrix.websocket-url.name }} using Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-client.yml
+++ b/.github/workflows/cross-client.yml
@@ -18,17 +18,12 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
 # Be sure to update both workflow files if you edit any env or trigger config
+concurrency:
+  group: cross-client-testing-build-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
   cross-client-testing:
     name: ${{ matrix.config-name }} ${{ matrix.test-name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -13,20 +13,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: network-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/network
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
   test:
     name: Lint & Test on Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -13,21 +13,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: protocol-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/protocol
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
   test-unit:
     name: Lint & Unit Test on Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-utils.yml
+++ b/.github/workflows/test-utils.yml
@@ -13,21 +13,14 @@ on:
   schedule:
     # run every day at 00:00
     - cron: '0 0 * * *'
-
+concurrency:
+  group: test-utils-build-${{ github.head_ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: packages/test-utils
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
   test-unit:
     name: Lint & Unit Test on Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR replaces 3rd party `styfle/cancel-workflow-action` with GitHub native `concurrency` keyword.

- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
- https://github.com/styfle/cancel-workflow-action/issues/76
