### PR TITLE
fix(client): Contract logging

### DIFF
--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -75,8 +75,10 @@ const createWrappedContractMethod = (
     concurrencyLimit: pLimit.Limit
 ) => {
     return async (...args: any) => {
-        eventEmitter.emit('onMethodExecute', methodName)
-        const returnValue = await withErrorHandling(() => concurrencyLimit(() => originalMethod(...args)), methodName)
+        const returnValue = await withErrorHandling(() => concurrencyLimit(() => {
+            eventEmitter.emit('onMethodExecute', methodName)
+            return originalMethod(...args)
+        }), methodName)
         if (isTransaction(returnValue)) {
             const tx = returnValue
             const originalWaitMethod = tx.wait


### PR DESCRIPTION
Logs when a contract method is executed, not when it is queue to be executed.