### PR TITLE
Fix trackerless broker image

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,6 +156,6 @@ jobs:
     with:
       docker_file: Dockerfile.broker
       image_name: streamr/broker-node
-      test_services_to_start: parity-node0 broker-node-storage-1
+      test_services_to_start: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph chainlink parity-node0 broker-node-storage-1
       build_platforms: linux/amd64
       test_script: bash ./.github/healthcheck.sh http://localhost:8791/info streamr-dev-broker-node-storage-1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,6 +156,6 @@ jobs:
     with:
       docker_file: Dockerfile.broker
       image_name: streamr/broker-node
-      test_services_to_start: parity-node0 broker-node-storage-1 broker-node-no-storage-1
+      test_services_to_start: parity-node0 broker-node-storage-1
       build_platforms: linux/amd64
-      test_script: bash ./.github/healthcheck.sh http://localhost:8791/info streamr-dev-broker-node-no-storage-1
+      test_script: bash ./.github/healthcheck.sh http://localhost:8791/info streamr-dev-broker-node-storage-1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -158,4 +158,4 @@ jobs:
       image_name: streamr/broker-node
       test_services_to_start: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph chainlink parity-node0 broker-node-storage-1
       build_platforms: linux/amd64
-      test_script: bash ./.github/healthcheck.sh http://localhost:8791/info streamr-dev-broker-node-storage-1
+      test_script: bash ./.github/healthcheck.sh http://localhost:8891/info streamr-dev-broker-node-storage-1

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -64,7 +64,7 @@
         "storage": {
             "cassandra": {
                 "hosts": [
-                    "cassandra"
+                    "10.200.10.1"
                 ],
                 "username": "",
                 "password": "",

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -64,7 +64,7 @@
         "storage": {
             "cassandra": {
                 "hosts": [
-                    "10.200.10.1"
+                    "cassandra"
                 ],
                 "username": "",
                 "password": "",


### PR DESCRIPTION
## Summary

Fixed problems with the broker's docker image tests in CI. The tests will now be ran using the storage node as it is acting as the default layer0 entrypoint in the Dev environment.
