### PR TITLE
feat(broker) [NET-1030]: send peerDescriptor in heartbeat messages to coordination stream

### DIFF
--- a/packages/broker/src/plugins/operator/AnnounceNodeToStreamService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeToStreamService.ts
@@ -23,17 +23,21 @@ export class AnnounceNodeToStreamService {
     }
 
     async start(): Promise<void> {
-        const nodeId = (await this.streamrClient.getNode()).getNodeId()
         setAbortableInterval(() => {
-            this.streamrClient.publish(this.coordinationStream, {
-                msgType: 'heartbeat',
-                nodeId
-            }).catch((err) => {
-                logger.warn('Unable to publish to coordination stream', {
-                    streamId: this.coordinationStream,
-                    reason: err?.message
-                })
-            })
+            (async () => {
+                try {
+                    const peerDescriptor = await this.streamrClient.getPeerDescriptor()
+                    await this.streamrClient.publish(this.coordinationStream, {
+                        msgType: 'heartbeat',
+                        peerDescriptor
+                    })
+                } catch (err) {
+                    logger.warn('Unable to publish to coordination stream', {
+                        streamId: this.coordinationStream,
+                        reason: err?.message
+                    })
+                }
+            })()
         }, this.intervalInMs, this.abortController.signal)
     }
 

--- a/packages/broker/test/unit/plugins/operator/AnnounceNodeToStreamService.test.ts
+++ b/packages/broker/test/unit/plugins/operator/AnnounceNodeToStreamService.test.ts
@@ -1,12 +1,20 @@
 import { AnnounceNodeToStreamService } from '../../../../src/plugins/operator/AnnounceNodeToStreamService'
-import { StreamrClient } from 'streamr-client'
+import { NetworkNodeType, StreamrClient } from 'streamr-client'
 import { mock, mockClear, MockProxy } from 'jest-mock-extended'
 import { toEthereumAddress, wait } from '@streamr/utils'
 import { toStreamID } from '@streamr/protocol'
 
-const ADDRESS = toEthereumAddress('0x61BBf708Fb7bB1D4dA10D1958C88A170988d3d1F')
-const NODE_ID = toEthereumAddress('0xA3B2B8AAAC099833275b1f7fCC415E121326D38c')
 const INTERVAL_IN_MS = 25
+const ADDRESS = toEthereumAddress('0x61BBf708Fb7bB1D4dA10D1958C88A170988d3d1F')
+const PEER_DESCRIPTOR = Object.freeze({
+    id: 'nodeId',
+    type: NetworkNodeType.NODEJS,
+    websocket: {
+        ip: '127.0.0.1',
+        port: 6666
+    },
+    openInternet: true
+})
 
 describe(AnnounceNodeToStreamService, () => {
 
@@ -15,9 +23,7 @@ describe(AnnounceNodeToStreamService, () => {
 
     beforeEach(async () => {
         streamrClient = mock<StreamrClient>()
-        streamrClient.getNode.mockResolvedValue({
-            getNodeId: () => NODE_ID
-        } as any)
+        streamrClient.getPeerDescriptor.mockResolvedValue(PEER_DESCRIPTOR)
         streamrClient.publish.mockResolvedValue(null as any)
         service = new AnnounceNodeToStreamService(streamrClient, ADDRESS, INTERVAL_IN_MS)
         await service.start()
@@ -32,7 +38,7 @@ describe(AnnounceNodeToStreamService, () => {
         expect(streamrClient.publish.mock.calls.length).toBeGreaterThan(10)
         expect(streamrClient.publish).toHaveBeenCalledWith(toStreamID('/operator/coordination', ADDRESS), {
             msgType: 'heartbeat',
-            nodeId: NODE_ID
+            peerDescriptor: PEER_DESCRIPTOR
         })
     })
 

--- a/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -11,6 +11,13 @@ const coordinationStreamId = toStreamID('/operator/coordination', ADDRESS)
 const READY_WAIT_MS = 500
 const JITTER = 100
 
+function createHeartbeatMsg(id: string): Record<string, unknown> {
+    return {
+        msgType: 'heartbeat',
+        peerDescriptor: { id }
+    }
+}
+
 describe(OperatorFleetState, () => {
     let streamrClient: MockProxy<StreamrClient>
     let subscription: MockProxy<Subscription>
@@ -64,7 +71,7 @@ describe(OperatorFleetState, () => {
 
     it('ignores non-heartbeat messages', async () => {
         await state.start()
-        await setTimeAndPublishMessage(10, { msgType: 'somethingElse', nodeId: 'a' })
+        await setTimeAndPublishMessage(10, { ...createHeartbeatMsg('a'), msgType: 'somethingElse' })
         expect(state.getNodeIds()).toEqual([])
     })
 
@@ -72,11 +79,11 @@ describe(OperatorFleetState, () => {
         const events = eventsWithArgsToArray(state as any, ['added', 'removed'])
         await state.start()
 
-        await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'b' })
-        await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'c' })
-        await setTimeAndPublishMessage(15, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(15, { msgType: 'heartbeat', nodeId: 'a' })
+        await setTimeAndPublishMessage(10, createHeartbeatMsg('a'))
+        await setTimeAndPublishMessage(10, createHeartbeatMsg('b'))
+        await setTimeAndPublishMessage(10, createHeartbeatMsg('c'))
+        await setTimeAndPublishMessage(15, createHeartbeatMsg('a'))
+        await setTimeAndPublishMessage(15, createHeartbeatMsg('a'))
 
         expect(state.getNodeIds()).toEqual(['a', 'b', 'c'])
         expect(events).toEqual([
@@ -90,12 +97,12 @@ describe(OperatorFleetState, () => {
         const events = eventsWithArgsToArray(state as any, ['added', 'removed'])
         await state.start()
 
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'c' })
-        await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'd' })
-        await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'c' })
-        await setTimeAndPublishMessage(19, { msgType: 'heartbeat', nodeId: 'e' })
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('a'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('b'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('c'))
+        await setTimeAndPublishMessage(10, createHeartbeatMsg('d'))
+        await setTimeAndPublishMessage(10, createHeartbeatMsg('c'))
+        await setTimeAndPublishMessage(19, createHeartbeatMsg('e'))
 
         await waitForCondition(() => state.getNodeIds().length <= 3)
         expect(state.getNodeIds()).toEqual(['c', 'd', 'e'])
@@ -113,15 +120,15 @@ describe(OperatorFleetState, () => {
     it('nodes can go and come back up again', async () => {
         await state.start()
 
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('a'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('b'))
         expect(state.getNodeIds()).toEqual(['a', 'b'])
 
-        await setTimeAndPublishMessage(15, { msgType: 'heartbeat', nodeId: 'b' })
+        await setTimeAndPublishMessage(15, createHeartbeatMsg('b'))
         await waitForEvent(state as any, 'removed')
         expect(state.getNodeIds()).toEqual(['b'])
 
-        await setTimeAndPublishMessage(18, { msgType: 'heartbeat', nodeId: 'a' })
+        await setTimeAndPublishMessage(18, createHeartbeatMsg('a'))
         expect(state.getNodeIds()).toEqual(['b', 'a'])
 
         currentTime = 30
@@ -136,10 +143,10 @@ describe(OperatorFleetState, () => {
 
     it('getLeaderNodeId returns leader node when nodes', async () => {
         await state.start()
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'd' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'c' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('d'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('a'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('c'))
+        await setTimeAndPublishMessage(5, createHeartbeatMsg('b'))
 
         expect(state.getLeaderNodeId()).toEqual('a')
     })
@@ -163,9 +170,9 @@ describe(OperatorFleetState, () => {
 
         it('eventually becomes ready if heartbeat arrives', async () => {
             await state.start()
-            await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
-            await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
-            await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'c' })
+            await setTimeAndPublishMessage(5, createHeartbeatMsg('a'))
+            await setTimeAndPublishMessage(5, createHeartbeatMsg('b'))
+            await setTimeAndPublishMessage(10, createHeartbeatMsg('c'))
             expect(ready).toBeFalse()
             await wait(READY_WAIT_MS + JITTER)
             expect(ready).toBeTrue()


### PR DESCRIPTION
## Summary

Send the full `JsonPeerDescriptor` (instead of just nodeId) in heartbeat messages to coordination stream. 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
