### PR TITLE
fix(DHT) optimise parallel joining with the use of a shared contacted peers set

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -1,7 +1,7 @@
 import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
 import { EventEmitter } from 'eventemitter3'
 import { RoutingRpcCommunicator } from '../transport/RoutingRpcCommunicator'
-import { PeerID, PeerIDKey } from '../helpers/PeerID'
+import { PeerID } from '../helpers/PeerID'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
@@ -449,10 +449,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
-        const contactedPeers = new Set<PeerIDKey>()
-        await Promise.all(entryPointDescriptors.map((entryPoint) =>
-            this.peerDiscovery!.joinDht(entryPoint, contactedPeers, doAdditionalRandomPeerDiscovery, retry)
-        ))
+        await this.peerDiscovery!.joinDht(entryPointDescriptors, doAdditionalRandomPeerDiscovery, retry)
     }
 
     public async startFind(key: Uint8Array, action?: FindAction, excludedPeer?: PeerDescriptor): Promise<FindResult> {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -1,7 +1,7 @@
 import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
 import { EventEmitter } from 'eventemitter3'
 import { RoutingRpcCommunicator } from '../transport/RoutingRpcCommunicator'
-import { PeerID } from '../helpers/PeerID'
+import { PeerID, PeerIDKey } from '../helpers/PeerID'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
@@ -449,8 +449,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
+        const contactedPeers = new Set<PeerIDKey>()
         await Promise.all(entryPointDescriptors.map((entryPoint) =>
-            this.peerDiscovery!.joinDht(entryPoint, doAdditionalRandomPeerDiscovery, retry)
+            this.peerDiscovery!.joinDht(entryPoint, contactedPeers, doAdditionalRandomPeerDiscovery, retry)
         ))
     }
 

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -18,6 +18,7 @@ interface DiscoverySessionConfig {
     parallelism: number
     noProgressLimit: number
     peerManager: PeerManager
+    // Note that contacted peers will be mutated by the DiscoverySession or other parallel sessions
     contactedPeers: Set<PeerIDKey>
 }
 

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -18,6 +18,7 @@ interface DiscoverySessionConfig {
     parallelism: number
     noProgressLimit: number
     peerManager: PeerManager
+    contactedPeers: Set<PeerIDKey>
 }
 
 export class DiscoverySession {
@@ -29,7 +30,6 @@ export class DiscoverySession {
     private noProgressCounter = 0
     private ongoingClosestPeersRequests: Set<string> = new Set()
     private readonly config: DiscoverySessionConfig
-    private contactedPeers: Set<PeerIDKey> = new Set()
 
     constructor(config: DiscoverySessionConfig) {
         this.config = config
@@ -48,7 +48,7 @@ export class DiscoverySession {
         }
         logger.trace(`Getting closest peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
         this.outgoingClosestPeersRequestsCounter++
-        this.contactedPeers.add(contact.getPeerId().toKey())
+        this.config.contactedPeers.add(contact.getPeerId().toKey())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
         this.config.peerManager.handlePeerActive(contact.getPeerId())
         return returnedContacts
@@ -83,7 +83,7 @@ export class DiscoverySession {
         if (this.stopped) {
             return
         }
-        const uncontacted = this.config.peerManager.getClosestContactsTo(this.config.targetId, this.config.parallelism, this.contactedPeers)
+        const uncontacted = this.config.peerManager.getClosestContactsTo(this.config.targetId, this.config.parallelism, this.config.contactedPeers)
         if (uncontacted.length === 0 || this.noProgressCounter >= this.config.noProgressLimit) {
             this.emitter.emit('discoveryCompleted')
             this.stopped = true
@@ -106,7 +106,7 @@ export class DiscoverySession {
     }
 
     public async findClosestNodes(timeout: number): Promise<void> {
-        if (this.config.peerManager.getNumberOfContacts(this.contactedPeers) === 0) {
+        if (this.config.peerManager.getNumberOfContacts(this.config.contactedPeers) === 0) {
             return
         }
         // TODO add abortController and signal it in stop()

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -38,7 +38,22 @@ export class PeerDiscovery {
     }
 
     async joinDht(
+        entryPoints: PeerDescriptor[],
+        doAdditionalRandomPeerDiscovery = true,
+        retry = true
+    ): Promise<void> {
+        const contactedPeers = new Set<PeerIDKey>()
+        await Promise.all(entryPoints.map((entryPoint) => this.joinThroughEntryPoint(
+            entryPoint,
+            contactedPeers,
+            doAdditionalRandomPeerDiscovery,
+            retry
+        )))
+    }
+
+    async joinThroughEntryPoint(
         entryPointDescriptor: PeerDescriptor,
+        // Note that this set is mutated by DiscoverySession
         contactedPeers: Set<PeerIDKey>,
         doAdditionalRandomPeerDiscovery = true,
         retry = true
@@ -107,7 +122,7 @@ export class PeerDiscovery {
         logger.debug(`Rejoining DHT ${this.config.serviceId}`)
         this.rejoinOngoing = true
         try {
-            await this.joinDht(entryPoint, new Set())
+            await this.joinThroughEntryPoint(entryPoint, new Set())
             logger.debug(`Rejoined DHT successfully ${this.config.serviceId}!`)
         } catch (err) {
             logger.warn(`Rejoining DHT ${this.config.serviceId} failed`)

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -37,7 +37,12 @@ export class PeerDiscovery {
         this.abortController = new AbortController()
     }
 
-    async joinDht(entryPointDescriptor: PeerDescriptor, contactedPeers: Set<PeerIDKey>, doAdditionalRandomPeerDiscovery = true, retry = true): Promise<void> {
+    async joinDht(
+        entryPointDescriptor: PeerDescriptor,
+        contactedPeers: Set<PeerIDKey>,
+        doAdditionalRandomPeerDiscovery = true,
+        retry = true
+    ): Promise<void> {
         if (this.isStopped()) {
             return
         }


### PR DESCRIPTION
## Summary

Optimised the parallel join operations by giving parallel join operations a shared set of contacted peers.

This is an important optimisation especially on layer1 where all requests are routed through layer0. In the worst cases we would be sending 4x more routed messages during joins than necessary.

Saw significant reduction in CPU usage in `benchmark/first-message.ts`

## Future improvements

- Investigate suspected increased in CPU usage for individual join operations. For example the DHT integration test `RoutedMessages.test.ts` uses 150% of cpu in a rather small network of 33 peers.
- The router could be refactored to have its own contacted set similar to the `DiscoverySessions`. 
- Parallel rejoins should use a shared set of contactedPeers as well

