### PR TITLE
fix(proto-rpc): Fix RpcCommunicator mem leak under timeouts

### DIFF
--- a/packages/proto-rpc/src/RpcCommunicator.ts
+++ b/packages/proto-rpc/src/RpcCommunicator.ts
@@ -38,15 +38,18 @@ export interface RpcCommunicatorConfig {
 class OngoingRequest {
 
     private deferredPromises: ResultParts
-    private timeoutRef: NodeJS.Timeout
+    private timeoutRef?: NodeJS.Timeout
 
-    constructor(deferredPromises: ResultParts, timeout: number, onTimeout: () => void) {
+    constructor(deferredPromises: ResultParts, timeoutConfig?: { timeout: number, onTimeout: () => void }) {
         this.deferredPromises = deferredPromises
-        this.timeoutRef = setTimeout(() => {
-            const error = new Err.RpcTimeout('Rpc request timed out', new Error())
-            this.rejectDeferredPromises(error, StatusCode.DEADLINE_EXCEEDED)
-            onTimeout()
-        }, timeout)
+        if (timeoutConfig) {
+            this.timeoutRef = setTimeout(() => {
+                const error = new Err.RpcTimeout('Rpc request timed out', new Error())
+                this.rejectDeferredPromises(error, StatusCode.DEADLINE_EXCEEDED)
+                timeoutConfig.onTimeout()
+            }, timeoutConfig.timeout)
+        }
+        
     }
 
     public resolveRequest(response: RpcMessage) {
@@ -188,7 +191,7 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
     private onOutgoingMessage(rpcMessage: RpcMessage, deferredPromises?: ResultParts, callContext?: ProtoCallContext): void {
         if (this.stopped) {
             if (deferredPromises) {
-                const ongoingRequest = new OngoingRequest(deferredPromises, 1000, () => {})
+                const ongoingRequest = new OngoingRequest(deferredPromises)
                 ongoingRequest.rejectRequest(new Error('stopped'), StatusCode.STOPPED)
             }
             return
@@ -211,7 +214,7 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
                         if (this.ongoingRequests.has(rpcMessage.requestId)) {
                             this.handleClientError(rpcMessage.requestId, clientSideException)
                         } else {
-                            const ongoingRequest = new OngoingRequest(deferredPromises, 1000, () => {})
+                            const ongoingRequest = new OngoingRequest(deferredPromises)
                             ongoingRequest.rejectRequest(clientSideException, StatusCode.SERVER_ERROR)
                         }
                     }
@@ -219,7 +222,7 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
                 .then(() => {
                     if (deferredPromises) {
                         if (!this.ongoingRequests.has(rpcMessage.requestId)) {
-                            const ongoingRequest = new OngoingRequest(deferredPromises, 1000, () => {})
+                            const ongoingRequest = new OngoingRequest(deferredPromises)
                             ongoingRequest.resolveNotification()
                         }
                     }
@@ -228,7 +231,7 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
         } else {
             if (deferredPromises) {
                 if (!this.ongoingRequests.has(rpcMessage.requestId)) {
-                    const ongoingRequest = new OngoingRequest(deferredPromises, 1000, () => {})
+                    const ongoingRequest = new OngoingRequest(deferredPromises)
                     ongoingRequest.resolveNotification()
                 }
             }
@@ -304,7 +307,13 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
             return
         }
 
-        const ongoingRequest = new OngoingRequest(deferredPromises, timeout, () => this.ongoingRequests.delete(requestId))
+        const ongoingRequest = new OngoingRequest(
+            deferredPromises, 
+            { 
+                timeout,
+                onTimeout: () => this.ongoingRequests.delete(requestId) 
+            }
+        )
 
         this.ongoingRequests.set(requestId, ongoingRequest)
     }

--- a/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
+++ b/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
@@ -66,17 +66,25 @@ describe('RpcCommunicator', () => {
     it('Resolves Promises', async () => {
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
+            // @ts-expect-error private 
+            expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         rpcCommunicator.handleIncomingMessage(responseRpcMessage)
         const pong = await promises.message.promise
         expect(pong).toEqual({ requestId: 'requestId' })
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(0)
     })
 
     it('Timeouts Promises', async () => {
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         await expect(promises.message.promise)
             .rejects
             .toEqual(new Err.RpcTimeout('Rpc request timed out'))
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(0)
     })
 
     it('Rejects on error response', async () => {
@@ -92,6 +100,8 @@ describe('RpcCommunicator', () => {
         await expect(promises.message.promise)
             .rejects
             .toEqual(new Err.RpcServerError('Server error on request'))
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(0)
     })
 
     it('Rejects on server timeout response', async () => {
@@ -106,6 +116,8 @@ describe('RpcCommunicator', () => {
         await expect(promises.message.promise)
             .rejects
             .toEqual(new Err.RpcTimeout('Server timed out on request'))
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(0)
     })
 
     it('Rejects on unknown method', async () => {
@@ -120,6 +132,8 @@ describe('RpcCommunicator', () => {
         await expect(promises.message.promise)
             .rejects
             .toEqual(new Err.RpcRequest(`Server does not implement method ping`))
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(0)
     })
 
     it('Success responses to requests', async () => {

--- a/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
+++ b/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
@@ -66,8 +66,8 @@ describe('RpcCommunicator', () => {
     it('Resolves Promises', async () => {
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
-            // @ts-expect-error private 
-            expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         rpcCommunicator.handleIncomingMessage(responseRpcMessage)
         const pong = await promises.message.promise
         expect(pong).toEqual({ requestId: 'requestId' })
@@ -96,6 +96,8 @@ describe('RpcCommunicator', () => {
         //response.body = RpcMessage.toBinary(errorResponse)
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         rpcCommunicator.handleIncomingMessage(errorResponse)
         await expect(promises.message.promise)
             .rejects
@@ -112,6 +114,8 @@ describe('RpcCommunicator', () => {
         //response.body = RpcMessage.toBinary(errorResponse)
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         rpcCommunicator.handleIncomingMessage(errorResponse)
         await expect(promises.message.promise)
             .rejects
@@ -128,6 +132,8 @@ describe('RpcCommunicator', () => {
         //response.body = RpcMessage.toBinary(errorResponse)
         // @ts-expect-error private 
         rpcCommunicator.onOutgoingMessage(request, promises)
+        // @ts-expect-error private 
+        expect(rpcCommunicator.ongoingRequests.size).toEqual(1)
         rpcCommunicator.handleIncomingMessage(errorResponse)
         await expect(promises.message.promise)
             .rejects


### PR DESCRIPTION
## Summary

If a request timed out it was not removed from the outgoingRequests map. This fix removes a major memory leak.

## Future improvements

- the new onTimeout handler could be made into a onCompleted function which would be a call back to remove OngoingRequests from the RpcCommunicator
