### PR TITLE
refactor(dht): [NET-1218] Use `NodeID` string internally

### DIFF
--- a/packages/dht/src/connection/ConnectionLockHandler.ts
+++ b/packages/dht/src/connection/ConnectionLockHandler.ts
@@ -1,17 +1,17 @@
 // Connection locks are independent of the existence of connections
 // that is why this class is needed
 
-import { PeerIDKey } from '../helpers/PeerID'
+import { NodeID } from '../helpers/nodeId'
 
 export type LockID = string
 
 export class ConnectionLockHandler {
 
-    private localLocks: Map<PeerIDKey, Set<LockID>> = new Map()
-    private remoteLocks: Map<PeerIDKey, Set<LockID>> = new Map()
+    private localLocks: Map<NodeID, Set<LockID>> = new Map()
+    private remoteLocks: Map<NodeID, Set<LockID>> = new Map()
     // TODO: remove weakLocks use localLocks instead. When opening weakLocks from the ConnectioManager,
     // simply do not send lock requests.
-    private weakLocks: Set<PeerIDKey> = new Set()
+    private weakLocks: Set<NodeID> = new Set()
 
     public getNumberOfLocalLockedConnections(): number {
         return this.localLocks.size
@@ -25,7 +25,7 @@ export class ConnectionLockHandler {
         return this.weakLocks.size
     }
 
-    public isLocalLocked(id: PeerIDKey, lockId?: LockID): boolean {
+    public isLocalLocked(id: NodeID, lockId?: LockID): boolean {
         if (lockId === undefined) {
             return this.localLocks.has(id)
         } else {
@@ -33,7 +33,7 @@ export class ConnectionLockHandler {
         }
     }
 
-    public isRemoteLocked(id: PeerIDKey, lockId?: LockID): boolean {
+    public isRemoteLocked(id: NodeID, lockId?: LockID): boolean {
         if (lockId === undefined) {
             return this.remoteLocks.has(id)
         } else {
@@ -45,33 +45,33 @@ export class ConnectionLockHandler {
         }
     }
 
-    private isWeakLocked(id: PeerIDKey): boolean {
+    private isWeakLocked(id: NodeID): boolean {
         return this.weakLocks.has(id)
     }
 
-    public isLocked(id: PeerIDKey): boolean {
+    public isLocked(id: NodeID): boolean {
         return (this.isLocalLocked(id) || this.isRemoteLocked(id) || this.isWeakLocked(id))
     }
 
-    public addLocalLocked(id: PeerIDKey, lockId: LockID): void {
+    public addLocalLocked(id: NodeID, lockId: LockID): void {
         if (!this.localLocks.has(id)) {
             this.localLocks.set(id, new Set())
         }
         this.localLocks.get(id)!.add(lockId)
     }
 
-    public addRemoteLocked(id: PeerIDKey, lockId: LockID): void {
+    public addRemoteLocked(id: NodeID, lockId: LockID): void {
         if (!this.remoteLocks.has(id)) {
             this.remoteLocks.set(id, new Set())
         }
         this.remoteLocks.get(id)!.add(lockId)
     }
 
-    public addWeakLocked(id: PeerIDKey): void {
+    public addWeakLocked(id: NodeID): void {
         this.weakLocks.add(id)
     }
 
-    public removeLocalLocked(id: PeerIDKey, lockId: LockID): void {
+    public removeLocalLocked(id: NodeID, lockId: LockID): void {
         if (this.localLocks.has(id)) {
             this.localLocks.get(id)?.delete(lockId)
             if (this.localLocks.get(id)?.size === 0) {
@@ -80,7 +80,7 @@ export class ConnectionLockHandler {
         }
     }
 
-    public removeRemoteLocked(id: PeerIDKey, lockId: LockID): void {
+    public removeRemoteLocked(id: NodeID, lockId: LockID): void {
         if (this.remoteLocks.has(id)) {
             this.remoteLocks.get(id)?.delete(lockId)
             if (this.remoteLocks.get(id)?.size === 0) {
@@ -89,11 +89,11 @@ export class ConnectionLockHandler {
         }
     }
 
-    public removeWeakLocked(id: PeerIDKey): void {
+    public removeWeakLocked(id: NodeID): void {
         this.weakLocks.delete(id)
     }
 
-    public clearAllLocks(id: PeerIDKey): void {
+    public clearAllLocks(id: NodeID): void {
         this.localLocks.delete(id)
         this.remoteLocks.delete(id)
         this.weakLocks.delete(id)

--- a/packages/dht/src/connection/ConnectionLockRpcLocal.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcLocal.ts
@@ -2,8 +2,7 @@ import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Logger } from '@streamr/utils'
 import {
     areEqualPeerDescriptors,
-    keyFromPeerDescriptor,
-    peerIdFromPeerDescriptor
+    getNodeIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
 import { Empty } from '../proto/google/protobuf/empty'
 import {
@@ -16,13 +15,13 @@ import {
 } from '../proto/packages/dht/protos/DhtRpc'
 import { IConnectionLockRpc } from '../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
-import { PeerIDKey } from '../helpers/PeerID'
 import { getNodeIdOrUnknownFromPeerDescriptor } from './ConnectionManager'
 import { LockID } from './ConnectionLockHandler'
+import { NodeID } from '../helpers/nodeId'
 
 interface ConnectionLockRpcLocalConfig {
-    addRemoteLocked: (id: PeerIDKey, lockId: LockID) => void
-    removeRemoteLocked: (id: PeerIDKey, lockId: LockID) => void
+    addRemoteLocked: (id: NodeID, lockId: LockID) => void
+    removeRemoteLocked: (id: NodeID, lockId: LockID) => void
     closeConnection: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean, reason?: string) => void
     getLocalPeerDescriptor: () => PeerDescriptor
 }
@@ -39,14 +38,14 @@ export class ConnectionLockRpcLocal implements IConnectionLockRpc {
 
     async lockRequest(lockRequest: LockRequest, context: ServerCallContext): Promise<LockResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const remotePeerId = peerIdFromPeerDescriptor(senderPeerDescriptor)
         if (areEqualPeerDescriptors(senderPeerDescriptor, this.config.getLocalPeerDescriptor())) {
             const response: LockResponse = {
                 accepted: false
             }
             return response
         }
-        this.config.addRemoteLocked(remotePeerId.toKey(), lockRequest.lockId)
+        const remoteNodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        this.config.addRemoteLocked(remoteNodeId, lockRequest.lockId)
         const response: LockResponse = {
             accepted: true
         }
@@ -55,8 +54,8 @@ export class ConnectionLockRpcLocal implements IConnectionLockRpc {
 
     async unlockRequest(unlockRequest: UnlockRequest, context: ServerCallContext): Promise<Empty> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const peerIdKey = keyFromPeerDescriptor(senderPeerDescriptor)
-        this.config.removeRemoteLocked(peerIdKey, unlockRequest.lockId)
+        const nodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        this.config.removeRemoteLocked(nodeId, unlockRequest.lockId)
         return {}
     }
 

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -4,12 +4,10 @@ import { EventEmitter } from 'eventemitter3'
 import { Contact } from '../dht/contact/Contact'
 import { SortedContactList } from '../dht/contact/SortedContactList'
 import { DuplicateDetector } from '../dht/routing/DuplicateDetector'
-import { PeerIDKey } from '../helpers/PeerID'
 import * as Err from '../helpers/errors'
 import {
     areEqualPeerDescriptors,
     getNodeIdFromPeerDescriptor,
-    keyFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
 import { protoToString } from '../helpers/protoToString'
@@ -34,6 +32,7 @@ import { ConnectionLockRpcRemote } from './ConnectionLockRpcRemote'
 import { WEBRTC_CLEANUP } from './webrtc/NodeWebrtcConnection'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ConnectionLockRpcLocal } from './ConnectionLockRpcLocal'
+import { NodeID } from '../helpers/nodeId'
 
 export interface ConnectionManagerConfig {
     maxConnections?: number
@@ -108,7 +107,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     private readonly duplicateMessageDetector: DuplicateDetector = new DuplicateDetector(100000, 100)
     private readonly metrics: ConnectionManagerMetrics
     private locks = new ConnectionLockHandler()
-    private connections: Map<PeerIDKey, ManagedConnection> = new Map()
+    private connections: Map<NodeID, ManagedConnection> = new Map()
     private readonly connectorFacade: ConnectorFacade
     private rpcCommunicator?: RoutingRpcCommunicator
     private disconnectorIntervalRef?: NodeJS.Timeout
@@ -136,8 +135,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             rpcRequestTimeout: 10000  // TODO use config option or named constant?
         })
         const lockRpcLocal = new ConnectionLockRpcLocal({
-            addRemoteLocked: (id: PeerIDKey, lockId: LockID) => this.locks.addRemoteLocked(id, lockId),
-            removeRemoteLocked: (id: PeerIDKey, lockId: LockID) => this.locks.removeRemoteLocked(id, lockId),
+            addRemoteLocked: (id: NodeID, lockId: LockID) => this.locks.addRemoteLocked(id, lockId),
+            removeRemoteLocked: (id: NodeID, lockId: LockID) => this.locks.removeRemoteLocked(id, lockId),
             closeConnection: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean, reason?: string) => {
                 // TODO should we have some handling for this floating promise?
                 this.closeConnection(peerDescriptor, gracefulLeave, reason)
@@ -163,7 +162,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             emitEvents: false
         })
         this.connections.forEach((connection) => {
-            if (!this.locks.isLocked(connection.peerIdKey) && Date.now() - connection.getLastUsed() > lastUsedLimit) {
+            if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsed() > lastUsedLimit) {
                 logger.trace('disconnecting in timeout interval: ' + getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()))
                 disconnectionCandidates.addContact(new Contact(connection.getPeerDescriptor()!))
             }
@@ -264,8 +263,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             ...message,
             sourceDescriptor: this.getLocalPeerDescriptor()
         }
-        const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
-        let connection = this.connections.get(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        let connection = this.connections.get(nodeId)
         if (!connection && !doNotConnect) {
             connection = this.connectorFacade.createConnection(peerDescriptor)
             this.onNewConnection(connection)
@@ -293,8 +292,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     }
 
     public getConnection(peerDescriptor: PeerDescriptor): ManagedConnection | undefined {
-        const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
-        return this.connections.get(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        return this.connections.get(nodeId)
     }
 
     public getLocalPeerDescriptor(): PeerDescriptor {
@@ -302,18 +301,18 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     }
 
     public hasConnection(peerDescriptor: PeerDescriptor): boolean {
-        const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
-        return this.connections.has(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        return this.connections.has(nodeId)
     }
 
     public hasLocalLockedConnection(peerDescriptor: PeerDescriptor): boolean {
-        const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
-        return this.locks.isLocalLocked(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        return this.locks.isLocalLocked(nodeId)
     }
 
     public hasRemoteLockedConnection(peerDescriptor: PeerDescriptor): boolean {
-        const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
-        return this.locks.isRemoteLocked(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        return this.locks.isRemoteLocked(nodeId)
     }
 
     public handleMessage(message: Message): void {
@@ -369,11 +368,11 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     private onDisconnected(connection: ManagedConnection, gracefulLeave: boolean) {
         logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()) + ' onDisconnected() gracefulLeave: ' + gracefulLeave)
 
-        const peerIdKey = keyFromPeerDescriptor(connection.getPeerDescriptor()!)
-        const storedConnection = this.connections.get(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!)
+        const storedConnection = this.connections.get(nodeId)
         if (storedConnection && storedConnection.connectionId.equals(connection.connectionId)) {
-            this.locks.clearAllLocks(peerIdKey)
-            this.connections.delete(peerIdKey)
+            this.locks.clearAllLocks(nodeId)
+            this.connections.delete(nodeId)
             logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor())
                 + ' deleted connection in onDisconnected() gracefulLeave: ' + gracefulLeave)
             this.emit('disconnected', connection.getPeerDescriptor()!, gracefulLeave)
@@ -415,13 +414,13 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     private acceptNewConnection(newConnection: ManagedConnection): boolean {
         logger.trace(getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!) + ' acceptIncomingConnection()')
         const newPeerID = peerIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
-        const peerIdKey = keyFromPeerDescriptor(newConnection.getPeerDescriptor()!)
-        if (this.connections.has(peerIdKey)) {
+        const nodeId = getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
+        if (this.connections.has(nodeId)) {
             if (newPeerID.hasSmallerHashThan(peerIdFromPeerDescriptor(this.getLocalPeerDescriptor()))) {
                 logger.trace(getNodeIdOrUnknownFromPeerDescriptor(newConnection.getPeerDescriptor())
                     + ' acceptIncomingConnection() replace current connection')
                 // replace the current connection
-                const oldConnection = this.connections.get(newPeerID.toKey())!
+                const oldConnection = this.connections.get(nodeId)!
                 logger.trace('replaced: ' + getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!))
                 const buffer = oldConnection.stealOutputBuffer()
 
@@ -437,14 +436,14 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }
 
         logger.trace(getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!) + ' added to connections at acceptIncomingConnection')
-        this.connections.set(peerIdKey, newConnection)
+        this.connections.set(nodeId, newConnection)
 
         return true
     }
 
     private async closeConnection(peerDescriptor: PeerDescriptor, gracefulLeave: boolean, reason?: string): Promise<void> {
         logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'closeConnection() ' + reason)
-        const id = keyFromPeerDescriptor(peerDescriptor)
+        const id = getNodeIdFromPeerDescriptor(peerDescriptor)
         this.locks.clearAllLocks(id)
         if (this.connections.has(id)) {
             const connectionToClose = this.connections.get(id)!
@@ -460,13 +459,13 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
             return
         }
-        const peerIdKey = keyFromPeerDescriptor(targetDescriptor)
+        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
         const rpcRemote = new ConnectionLockRpcRemote(
             this.getLocalPeerDescriptor(),
             targetDescriptor,
             toProtoRpcClient(new ConnectionLockRpcClient(this.rpcCommunicator!.getRpcClientTransport()))
         )
-        this.locks.addLocalLocked(peerIdKey, lockId)
+        this.locks.addLocalLocked(nodeId, lockId)
         rpcRemote.lockRequest(lockId)
             .then((_accepted) => logger.trace('LockRequest successful'))
             .catch((err) => { logger.debug(err) })
@@ -476,14 +475,14 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
             return
         }
-        const peerIdKey = keyFromPeerDescriptor(targetDescriptor)
-        this.locks.removeLocalLocked(peerIdKey, lockId)
+        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
+        this.locks.removeLocalLocked(nodeId, lockId)
         const rpcRemote = new ConnectionLockRpcRemote(
             this.getLocalPeerDescriptor(),
             targetDescriptor,
             toProtoRpcClient(new ConnectionLockRpcClient(this.rpcCommunicator!.getRpcClientTransport()))
         )
-        if (this.connections.has(peerIdKey)) {
+        if (this.connections.has(nodeId)) {
             rpcRemote.unlockRequest(lockId)
         }
     }
@@ -492,22 +491,21 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
             return
         }
-        const peerIdKey = keyFromPeerDescriptor(targetDescriptor)
-        this.locks.addWeakLocked(peerIdKey)
+        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
+        this.locks.addWeakLocked(nodeId)
     }
 
     public weakUnlockConnection(targetDescriptor: PeerDescriptor): void {
         if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
             return
         }
-        const peerIdKey = keyFromPeerDescriptor(targetDescriptor)
-        this.locks.removeWeakLocked(peerIdKey)
-
+        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
+        this.locks.removeWeakLocked(nodeId)
     }
 
     private async gracefullyDisconnectAsync(targetDescriptor: PeerDescriptor, disconnectMode: DisconnectMode): Promise<void> {
 
-        const connection = this.connections.get(peerIdFromPeerDescriptor(targetDescriptor).toKey())
+        const connection = this.connections.get(getNodeIdFromPeerDescriptor(targetDescriptor))
 
         if (!connection) {
             logger.debug('gracefullyDisconnectedAsync() tried on a non-existing connection')

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -157,7 +157,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             return
         }
         const disconnectionCandidates = new SortedContactList<Contact>({
-            referenceId: peerIdFromPeerDescriptor(this.getLocalPeerDescriptor()), 
+            referenceId: getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()), 
             maxSize: 100000,  // TODO use config option or named constant?
             allowToContainReferenceId: false,
             emitEvents: false

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -4,9 +4,9 @@ import { Handshaker } from './Handshaker'
 import { HandshakeError, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { Logger, runAndRaceEvents3, RunAndRaceEventsReturnType } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
-import { PeerIDKey } from '../helpers/PeerID'
-import { keyFromPeerDescriptor } from '../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../helpers/peerIdFromPeerDescriptor'
 import { getNodeIdOrUnknownFromPeerDescriptor } from './ConnectionManager'
+import { NodeID } from '../helpers/nodeId'
 
 export interface ManagedConnectionEvents {
     managedData: (bytes: Uint8Array, remotePeerDescriptor: PeerDescriptor) => void
@@ -166,8 +166,8 @@ export class ManagedConnection extends EventEmitter<Events> {
         return this
     }
 
-    public get peerIdKey(): PeerIDKey {
-        return keyFromPeerDescriptor(this.remotePeerDescriptor!)
+    public getNodeId(): NodeID {
+        return getNodeIdFromPeerDescriptor(this.remotePeerDescriptor!)
     }
 
     public getLastUsed(): number {

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/parameter-properties */
 import EventEmitter from 'eventemitter3'
-import { PeerIDKey } from '../../helpers/PeerID'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { ConnectionSourceEvents } from '../IConnectionSource'
 import { SimulatorConnector } from './SimulatorConnector'
@@ -8,10 +7,11 @@ import { SimulatorConnection } from './SimulatorConnection'
 import { ConnectionID } from '../IConnection'
 import { Logger } from '@streamr/utils'
 import { getRegionDelayMatrix } from './pings'
-import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import Heap from 'heap'
 import { debugVars } from '../../helpers/debugHelpers'
 import * as sinon from 'sinon'
+import { NodeID } from '../../helpers/nodeId'
 
 // TODO take this from @streamr/test-utils (we can't access devDependencies as Simulator
 // is currently in "src" directory instead of "test" directory)
@@ -102,7 +102,7 @@ class CloseOperation extends SimulatorOperation {
 
 export class Simulator extends EventEmitter<ConnectionSourceEvents> {
     private stopped = false
-    private connectors: Map<PeerIDKey, SimulatorConnector> = new Map()
+    private connectors: Map<NodeID, SimulatorConnector> = new Map()
     private latencyTable?: Array<Array<number>>
     private associations: Map<ConnectionID, Association> = new Map()
 
@@ -214,11 +214,11 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
     }
 
     public addConnector(connector: SimulatorConnector): void {
-        this.connectors.set(keyFromPeerDescriptor(connector.getPeerDescriptor()), connector)
+        this.connectors.set(getNodeIdFromPeerDescriptor(connector.getPeerDescriptor()), connector)
     }
 
     private executeConnectOperation(operation: ConnectOperation): void {
-        const target = this.connectors.get(keyFromPeerDescriptor(operation.targetDescriptor))
+        const target = this.connectors.get(getNodeIdFromPeerDescriptor(operation.targetDescriptor))
 
         if (!target) {
             logger.error('Target connector not found when executing connect operation')

--- a/packages/dht/src/connection/simulator/SimulatorConnector.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnector.ts
@@ -6,16 +6,16 @@ import {
 } from '../../proto/packages/dht/protos/DhtRpc'
 import { Logger } from '@streamr/utils'
 import { ManagedConnection } from '../ManagedConnection'
-import { PeerIDKey } from '../../helpers/PeerID'
 import { Simulator } from './Simulator'
 import { SimulatorConnection } from './SimulatorConnection'
-import { getNodeIdFromPeerDescriptor, keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { NodeID } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
 export class SimulatorConnector {
 
-    private connectingConnections: Map<PeerIDKey, ManagedConnection> = new Map()
+    private connectingConnections: Map<NodeID, ManagedConnection> = new Map()
     private stopped = false
     private localPeerDescriptor: PeerDescriptor
     private simulator: Simulator
@@ -33,8 +33,8 @@ export class SimulatorConnector {
 
     public connect(targetPeerDescriptor: PeerDescriptor): ManagedConnection {
         logger.trace('connect() ' + getNodeIdFromPeerDescriptor(targetPeerDescriptor))
-        const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
-        const existingConnection = this.connectingConnections.get(peerKey)
+        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const existingConnection = this.connectingConnections.get(nodeId)
         if (existingConnection) {
             return existingConnection
         }
@@ -44,12 +44,12 @@ export class SimulatorConnector {
         const managedConnection = new ManagedConnection(this.localPeerDescriptor, ConnectionType.SIMULATOR_CLIENT, connection, undefined)
         managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
 
-        this.connectingConnections.set(peerKey, managedConnection)
+        this.connectingConnections.set(nodeId, managedConnection)
         connection.once('disconnected', () => {
-            this.connectingConnections.delete(peerKey)
+            this.connectingConnections.delete(nodeId)
         })
         connection.once('connected', () => {
-            this.connectingConnections.delete(peerKey)
+            this.connectingConnections.delete(nodeId)
         })
 
         connection.connect()

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -5,7 +5,7 @@ import EventEmitter from 'eventemitter3'
 import nodeDatachannel, { DataChannel, DescriptionType, PeerConnection } from 'node-datachannel'
 import { Logger } from '@streamr/utils'
 import { IllegalRtcPeerConnectionState } from '../../helpers/errors'
-import { getNodeIdFromPeerDescriptor, keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { iceServerAsString } from './iceServerAsString'
 import { IceServer } from './WebrtcConnector'
 import { PortRange } from '../ConnectionManager'
@@ -80,9 +80,9 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     }
 
     public start(isOffering: boolean): void {
-        const peerIdKey = keyFromPeerDescriptor(this.remotePeerDescriptor)
+        const nodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
         logger.trace(`Starting new connection for peer ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`, { isOffering })
-        this.connection = new PeerConnection(peerIdKey, {
+        this.connection = new PeerConnection(nodeId, {
             iceServers: this.iceServers.map(iceServerAsString),
             maxMessageSize: this.maxMessageSize,
             portRangeBegin: this.portRange?.min,

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -9,7 +9,6 @@ import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicat
 import { NodeWebrtcConnection } from './NodeWebrtcConnection'
 import { WebrtcConnectorRpcRemote } from './WebrtcConnectorRpcRemote'
 import { WebrtcConnectorRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
-import { PeerIDKey } from '../../helpers/PeerID'
 import { ManagedWebrtcConnection } from '../ManagedWebrtcConnection'
 import { Logger } from '@streamr/utils'
 import * as Err from '../../helpers/errors'
@@ -18,12 +17,12 @@ import { toProtoRpcClient } from '@streamr/proto-rpc'
 import {
     areEqualPeerDescriptors,
     getNodeIdFromPeerDescriptor,
-    keyFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../../helpers/peerIdFromPeerDescriptor'
 import { PortRange } from '../ConnectionManager'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { WebrtcConnectorRpcLocal } from './WebrtcConnectorRpcLocal'
+import { NodeID } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -60,7 +59,7 @@ export class WebrtcConnector {
 
     private static readonly WEBRTC_CONNECTOR_SERVICE_ID = 'system/webrtc-connector'
     private readonly rpcCommunicator: ListeningRpcCommunicator
-    private readonly ongoingConnectAttempts: Map<PeerIDKey, ManagedWebrtcConnection> = new Map()
+    private readonly ongoingConnectAttempts: Map<NodeID, ManagedWebrtcConnection> = new Map()
     private localPeerDescriptor?: PeerDescriptor
     private stopped = false
     private iceServers: IceServer[]
@@ -135,8 +134,8 @@ export class WebrtcConnector {
 
         logger.trace(`Opening WebRTC connection to ${getNodeIdFromPeerDescriptor(targetPeerDescriptor)}`)
 
-        const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
-        const existingConnection = this.ongoingConnectAttempts.get(peerKey)
+        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const existingConnection = this.ongoingConnectAttempts.get(nodeId)
         if (existingConnection) {
             return existingConnection
         }
@@ -161,10 +160,10 @@ export class WebrtcConnector {
 
         managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
 
-        this.ongoingConnectAttempts.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+        this.ongoingConnectAttempts.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
 
         const delFunc = () => {
-            this.ongoingConnectAttempts.delete(peerKey)
+            this.ongoingConnectAttempts.delete(nodeId)
             connection.off('disconnected', delFunc)
             managedConnection.off('handshakeCompleted', delFunc)
         }

--- a/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
@@ -2,8 +2,7 @@ import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
 import { Logger } from '@streamr/utils'
 import { getAddressFromIceCandidate, isPrivateIPv4 } from '../../helpers/AddressTools'
-import { PeerIDKey } from '../../helpers/PeerID'
-import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Empty } from '../../proto/google/protobuf/empty'
 import {
     IceCandidate,
@@ -19,6 +18,7 @@ import { ManagedConnection } from '../ManagedConnection'
 import { ManagedWebrtcConnection } from '../ManagedWebrtcConnection'
 import { NodeWebrtcConnection } from './NodeWebrtcConnection'
 import { WebrtcConnectorRpcRemote } from './WebrtcConnectorRpcRemote'
+import { NodeID } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -26,7 +26,7 @@ interface WebrtcConnectorRpcLocalConfig {
     connect: (targetPeerDescriptor: PeerDescriptor) => ManagedConnection 
     onNewConnection: (connection: ManagedConnection) => boolean
     // TODO pass accessor methods instead of passing a mutable entity
-    ongoingConnectAttempts: Map<PeerIDKey, ManagedWebrtcConnection>
+    ongoingConnectAttempts: Map<NodeID, ManagedWebrtcConnection>
     rpcCommunicator: ListeningRpcCommunicator
     getLocalPeerDescriptor: () => PeerDescriptor
     allowPrivateAddresses: boolean
@@ -42,7 +42,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async requestConnection(context: ServerCallContext): Promise<Empty> {
         const targetPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        if (this.config.ongoingConnectAttempts.has(keyFromPeerDescriptor(targetPeerDescriptor))) {
+        if (this.config.ongoingConnectAttempts.has(getNodeIdFromPeerDescriptor(targetPeerDescriptor))) {
             return {}
         }
         const managedConnection = this.config.connect(targetPeerDescriptor)
@@ -53,15 +53,15 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async rtcOffer(request: RtcOffer, context: ServerCallContext): Promise<Empty> {
         const remotePeer = (context as DhtCallContext).incomingSourceDescriptor!
-        const peerKey = keyFromPeerDescriptor(remotePeer)
-        let managedConnection = this.config.ongoingConnectAttempts.get(peerKey)
+        const nodeId = getNodeIdFromPeerDescriptor(remotePeer)
+        let managedConnection = this.config.ongoingConnectAttempts.get(nodeId)
         let connection = managedConnection?.getWebrtcConnection()
 
         if (!managedConnection) {
             connection = new NodeWebrtcConnection({ remotePeerDescriptor: remotePeer })
             managedConnection = new ManagedWebrtcConnection(this.config.getLocalPeerDescriptor(), undefined, connection)
             managedConnection.setRemotePeerDescriptor(remotePeer)
-            this.config.ongoingConnectAttempts.set(peerKey, managedConnection)
+            this.config.ongoingConnectAttempts.set(nodeId, managedConnection)
             this.config.onNewConnection(managedConnection)
             const remoteConnector = new WebrtcConnectorRpcRemote(
                 this.config.getLocalPeerDescriptor(),
@@ -82,8 +82,8 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
         connection!.setRemoteDescription(request.description, 'offer')
 
         managedConnection.on('handshakeRequest', () => {
-            if (this.config.ongoingConnectAttempts.has(peerKey)) {
-                this.config.ongoingConnectAttempts.delete(peerKey)
+            if (this.config.ongoingConnectAttempts.has(nodeId)) {
+                this.config.ongoingConnectAttempts.delete(nodeId)
             }
             managedConnection!.acceptHandshake()
         })
@@ -92,8 +92,8 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async rtcAnswer(request: RtcAnswer, context: ServerCallContext): Promise<Empty> {
         const remotePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const peerKey = keyFromPeerDescriptor(remotePeerDescriptor)
-        const connection = this.config.ongoingConnectAttempts.get(peerKey)?.getWebrtcConnection()
+        const nodeId = getNodeIdFromPeerDescriptor(remotePeerDescriptor)
+        const connection = this.config.ongoingConnectAttempts.get(nodeId)?.getWebrtcConnection()
         if (!connection) {
             return {}
         } else if (connection.connectionId.toString() !== request.connectionId) {
@@ -106,9 +106,8 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async iceCandidate(request: IceCandidate, context: ServerCallContext): Promise<Empty> {
         const remotePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const peerKey = keyFromPeerDescriptor(remotePeerDescriptor)
-        const connection = this.config.ongoingConnectAttempts.get(peerKey)?.getWebrtcConnection()
-
+        const nodeId = getNodeIdFromPeerDescriptor(remotePeerDescriptor)
+        const connection = this.config.ongoingConnectAttempts.get(nodeId)?.getWebrtcConnection()
         if (!connection) {
             return {}
         } else if (connection.connectionId.toString() !== request.connectionId) {

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -18,11 +18,10 @@ import { ManagedConnection } from '../ManagedConnection'
 import { WebsocketServer } from './WebsocketServer'
 import { sendConnectivityRequest } from '../connectivityChecker'
 import { NatType, PortRange, TlsCertificate } from '../ConnectionManager'
-import { PeerIDKey } from '../../helpers/PeerID'
 import { ServerWebsocket } from './ServerWebsocket'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
 import { Handshaker } from '../Handshaker'
-import { areEqualPeerDescriptors, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { ParsedUrlQuery } from 'querystring'
 import { range, sample } from 'lodash'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
@@ -31,6 +30,7 @@ import { WebsocketServerStartError } from '../../helpers/errors'
 import { AutoCertifierClientFacade } from './AutoCertifierClientFacade'
 import { attachConnectivityRequestHandler } from '../connectivityRequestHandler'
 import * as Err from '../../helpers/errors'
+import { NodeID } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -61,7 +61,7 @@ export class WebsocketConnector {
     private static readonly WEBSOCKET_CONNECTOR_SERVICE_ID = 'system/websocket-connector'
     private readonly rpcCommunicator: ListeningRpcCommunicator
     private readonly websocketServer?: WebsocketServer
-    private readonly ongoingConnectRequests: Map<PeerIDKey, ManagedConnection> = new Map()
+    private readonly ongoingConnectRequests: Map<NodeID, ManagedConnection> = new Map()
     private onNewConnection: (connection: ManagedConnection) => boolean
     private host?: string
     private readonly entrypoints?: PeerDescriptor[]
@@ -73,7 +73,7 @@ export class WebsocketConnector {
     private autoCertifierClient?: AutoCertifierClientFacade
     private selectedPort?: number
     private localPeerDescriptor?: PeerDescriptor
-    private connectingConnections: Map<PeerIDKey, ManagedConnection> = new Map()
+    private connectingConnections: Map<NodeID, ManagedConnection> = new Map()
     private abortController = new AbortController()
 
     constructor(config: WebsocketConnectorConfig) {
@@ -101,10 +101,10 @@ export class WebsocketConnector {
         const rpcLocal = new WebsocketConnectorRpcLocal({
             connect: (targetPeerDescriptor: PeerDescriptor) => this.connect(targetPeerDescriptor),
             hasConnection: (targetPeerDescriptor: PeerDescriptor): boolean => {
-                const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
-                if (this.connectingConnections.has(peerKey)
-                    || this.connectingConnections.has(peerKey)
-                    || this.ongoingConnectRequests.has(peerKey)
+                const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+                if (this.connectingConnections.has(nodeId)
+                    || this.connectingConnections.has(nodeId)
+                    || this.ongoingConnectRequests.has(nodeId)
                 ) {
                     return true
                 } else {
@@ -229,8 +229,8 @@ export class WebsocketConnector {
     }
 
     public connect(targetPeerDescriptor: PeerDescriptor): ManagedConnection {
-        const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
-        const existingConnection = this.connectingConnections.get(peerKey)
+        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const existingConnection = this.connectingConnections.get(nodeId)
         if (existingConnection) {
             return existingConnection
         }
@@ -251,11 +251,11 @@ export class WebsocketConnector {
             )
             managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
 
-            this.connectingConnections.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+            this.connectingConnections.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
 
             const delFunc = () => {
-                if (this.connectingConnections.has(peerKey)) {
-                    this.connectingConnections.delete(peerKey)
+                if (this.connectingConnections.has(nodeId)) {
+                    this.connectingConnections.delete(nodeId)
                 }
                 socket.off('disconnected', delFunc)
                 managedConnection.off('handshakeCompleted', delFunc)
@@ -292,9 +292,9 @@ export class WebsocketConnector {
             undefined,
             targetPeerDescriptor
         )
-        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(keyFromPeerDescriptor(targetPeerDescriptor)))
+        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(getNodeIdFromPeerDescriptor(targetPeerDescriptor)))
         managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
-        this.ongoingConnectRequests.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+        this.ongoingConnectRequests.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
         return managedConnection
     }
 
@@ -303,13 +303,12 @@ export class WebsocketConnector {
         serverWebsocket: IConnection,
         targetPeerDescriptor?: PeerDescriptor
     ) {
-        const peerId = peerIdFromPeerDescriptor(sourcePeerDescriptor)
-
-        if (this.ongoingConnectRequests.has(peerId.toKey())) {
-            const ongoingConnectRequest = this.ongoingConnectRequests.get(peerId.toKey())!
+        const nodeId = getNodeIdFromPeerDescriptor(sourcePeerDescriptor)
+        if (this.ongoingConnectRequests.has(nodeId)) {
+            const ongoingConnectRequest = this.ongoingConnectRequests.get(nodeId)!
             ongoingConnectRequest.attachImplementation(serverWebsocket)
             ongoingConnectRequest.acceptHandshake()
-            this.ongoingConnectRequests.delete(peerId.toKey())
+            this.ongoingConnectRequests.delete(nodeId)
         } else {
             const managedConnection = new ManagedConnection(
                 this.localPeerDescriptor!,
@@ -318,9 +317,7 @@ export class WebsocketConnector {
                 serverWebsocket,
                 targetPeerDescriptor
             )
-
             managedConnection.setRemotePeerDescriptor(sourcePeerDescriptor)
-
             if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {
                 managedConnection.rejectHandshake(HandshakeError.INVALID_TARGET_PEER_DESCRIPTOR)
             } else if (this.onNewConnection(managedConnection)) {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -53,7 +53,7 @@ import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ExternalApiRpcLocal } from './ExternalApiRpcLocal'
 import { PeerManager, getDistance } from './PeerManager'
 import { ServiceID } from '../types/ServiceID'
-import { getNodeIdFromBinary } from '../helpers/nodeId'
+import { NodeID, getNodeIdFromBinary } from '../helpers/nodeId'
 
 export interface DhtNodeEvents {
     newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
@@ -386,9 +386,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         )
     }
 
-    private isPeerCloserToIdThanSelf(peer: PeerDescriptor, compareToId: PeerID): boolean {
-        const distance1 = getDistance(getNodeIdFromPeerDescriptor(peer), compareToId.toNodeId())
-        const distance2 = getDistance(this.getNodeId().toNodeId(), compareToId.toNodeId())
+    private isPeerCloserToIdThanSelf(peer: PeerDescriptor, compareToId: NodeID): boolean {
+        const distance1 = getDistance(getNodeIdFromPeerDescriptor(peer), compareToId)
+        const distance2 = getDistance(this.getNodeId().toNodeId(), compareToId)
         return distance1 < distance2
     }
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -33,8 +33,7 @@ import { toProtoRpcClient } from '@streamr/proto-rpc'
 import { Any } from '../proto/google/protobuf/any'
 import {
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor,
-    peerIdFromPeerDescriptor
+    getNodeIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
 import { Router } from './routing/Router'
 import { RecursiveOperationManager, RecursiveOperationResult } from './recursive-operation/RecursiveOperationManager'
@@ -301,7 +300,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.peerManager = new PeerManager({
             numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
             maxContactListSize: this.config.maxNeighborListSize,
-            localNodeId: this.getNodeId().toNodeId(),
+            localNodeId: this.getNodeId(),
             connectionManager: this.connectionManager!,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             isLayer0: (this.connectionManager !== undefined),
@@ -388,7 +387,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     private isPeerCloserToIdThanSelf(peer: PeerDescriptor, compareToId: NodeID): boolean {
         const distance1 = getDistance(getNodeIdFromPeerDescriptor(peer), compareToId)
-        const distance2 = getDistance(this.getNodeId().toNodeId(), compareToId)
+        const distance2 = getDistance(this.getNodeId(), compareToId)
         return distance1 < distance2
     }
 
@@ -420,8 +419,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         )
     }
     
-    public getNodeId(): PeerID {
-        return peerIdFromPeerDescriptor(this.localPeerDescriptor!)
+    public getNodeId(): NodeID {
+        return getNodeIdFromPeerDescriptor(this.localPeerDescriptor!)
     }
 
     public getNumberOfNeighbors(): number {

--- a/packages/dht/src/dht/DhtNodeRpcRemote.ts
+++ b/packages/dht/src/dht/DhtNodeRpcRemote.ts
@@ -9,9 +9,9 @@ import { v4 } from 'uuid'
 import { Logger } from '@streamr/utils'
 import { ProtoRpcClient } from '@streamr/proto-rpc'
 import { RpcRemote } from './contact/RpcRemote'
-import { PeerID } from '../helpers/PeerID'
-import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../helpers/peerIdFromPeerDescriptor'
 import { ServiceID } from '../types/ServiceID'
+import { NodeID } from '../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -35,7 +35,7 @@ export class DhtNodeRpcRemote extends RpcRemote<IDhtNodeRpcClient> implements KB
         rpcRequestTimeout?: number
     ) {
         super(localPeerDescriptor, peerDescriptor, serviceId, client, rpcRequestTimeout)
-        this.id = this.getPeerId().value
+        this.id = this.getPeerDescriptor().nodeId
         this.vectorClock = DhtNodeRpcRemote.counter++
     }
 
@@ -84,7 +84,7 @@ export class DhtNodeRpcRemote extends RpcRemote<IDhtNodeRpcClient> implements KB
         })
     }
 
-    getPeerId(): PeerID {
-        return peerIdFromPeerDescriptor(this.getPeerDescriptor())
+    getNodeId(): NodeID {
+        return getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
     }
 }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -1,5 +1,5 @@
 import {
-    Logger
+    Logger, hexToBinary
 } from '@streamr/utils'
 import KBucket from 'k-bucket'
 import { PeerID, PeerIDKey } from '../helpers/PeerID'
@@ -16,6 +16,7 @@ import { RandomContactList } from './contact/RandomContactList'
 import { SortedContactList } from './contact/SortedContactList'
 import { ConnectionManager } from '../connection/ConnectionManager'
 import EventEmitter from 'eventemitter3'
+import { areEqualNodeIds, getNodeIdFromBinary } from '../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -79,7 +80,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             // TODO: Update contact info to the connection manager and reconnect
         })
         this.contacts = new SortedContactList({
-            referenceId: this.config.ownPeerId, 
+            referenceId: this.config.ownPeerId.toNodeId(), 
             maxSize: this.config.maxContactListSize,
             allowToContainReferenceId: false,
             emitEvents: true
@@ -94,7 +95,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.contacts.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('newContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
-        this.randomPeers = new RandomContactList(this.config.ownPeerId, this.config.maxContactListSize)
+        this.randomPeers = new RandomContactList(this.config.ownPeerId.toNodeId(), this.config.maxContactListSize)
         this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
@@ -108,7 +109,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList({
-            referenceId: this.config.ownPeerId, 
+            referenceId: this.config.ownPeerId.toNodeId(), 
             maxSize: 100,  // TODO use config option or named constant?
             allowToContainReferenceId: false,
             emitEvents: false
@@ -173,7 +174,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
 
     private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
         for (const contactId of this.contacts!.getContactIds()) {
-            if (!this.bucket!.get(contactId.value) && this.contacts!.isActive(contactId)) {
+            if (!this.bucket!.get(hexToBinary(contactId)) && this.contacts!.isActive(contactId)) {
                 return this.contacts!.getContact(contactId)!.contact
             }
         }
@@ -219,8 +220,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         logger.trace(`Removing contact ${getNodeIdFromPeerDescriptor(contact)}`)
         const peerId = peerIdFromPeerDescriptor(contact)
         this.bucket!.remove(peerId.value)
-        this.contacts!.removeContact(peerId)
-        this.randomPeers!.removeContact(peerId)
+        this.contacts!.removeContact(peerId.toNodeId())
+        this.randomPeers!.removeContact(peerId.toNodeId())
     }
 
     stop(): void {
@@ -237,7 +238,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
 
     getClosestNeighborsTo(kademliaId: Uint8Array, limit?: number, excludeSet?: Set<PeerIDKey>): DhtNodeRpcRemote[] {
         const closest = new SortedContactList<DhtNodeRpcRemote>({
-            referenceId: PeerID.fromValue(kademliaId),
+            referenceId: getNodeIdFromBinary(kademliaId),
             allowToContainReferenceId: true,
             emitEvents: false
         }) 
@@ -255,7 +256,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     // TODO reduce copy-paste?
     getClosestContactsTo(kademliaId: Uint8Array, limit?: number, excludeSet?: Set<PeerIDKey>): DhtNodeRpcRemote[] {
         const closest = new SortedContactList<DhtNodeRpcRemote>({
-            referenceId: PeerID.fromValue(kademliaId),
+            referenceId: getNodeIdFromBinary(kademliaId),
             allowToContainReferenceId: true,
             emitEvents: false
         })
@@ -293,12 +294,12 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     }
 
     handlePeerActive(peerId: PeerID): void {
-        this.contacts!.setActive(peerId)
+        this.contacts!.setActive(peerId.toNodeId())
     }
 
     handlePeerUnresponsive(peerId: PeerID): void {
         this.bucket!.remove(peerId.value)
-        this.contacts!.removeContact(peerId)
+        this.contacts!.removeContact(peerId.toNodeId())
     }
 
     handleNewPeers(peerDescriptors: PeerDescriptor[], setActive?: boolean): void { 
@@ -306,12 +307,12 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         peerDescriptors.forEach((contact) => {
-            const peerId = peerIdFromPeerDescriptor(contact)
-            if (!peerId.equals(this.config.ownPeerId)) {
+            const nodeId = getNodeIdFromPeerDescriptor(contact)
+            if (!areEqualNodeIds(nodeId, this.config.ownPeerId.toNodeId())) {
                 logger.trace(`Adding new contact ${getNodeIdFromPeerDescriptor(contact)}`)
                 const remote = this.config.createDhtNodeRpcRemote(contact)
                 const isInBucket = (this.bucket!.get(contact.nodeId) !== null)
-                const isInNeighborList = (this.contacts!.getContact(peerId) !== undefined)
+                const isInNeighborList = (this.contacts!.getContact(nodeId) !== undefined)
                 if (isInBucket || isInNeighborList) {
                     this.randomPeers!.addContact(remote)
                 }
@@ -322,7 +323,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
                     this.contacts!.addContact(remote)
                 } 
                 if (setActive) {
-                    this.contacts!.setActive(peerId)
+                    this.contacts!.setActive(nodeId)
                 }
             }
         })

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -114,7 +114,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         sortingList.addContacts(oldContacts)
         const sortedContacts = sortingList.getAllContacts()
         this.config.connectionManager?.weakUnlockConnection(sortedContacts[sortedContacts.length - 1].getPeerDescriptor())
-        this.bucket?.remove(sortedContacts[sortedContacts.length - 1].getPeerId().value)    
+        this.bucket?.remove(hexToBinary(sortedContacts[sortedContacts.length - 1].getNodeId()))
         this.bucket!.add(newContact)
     }
 
@@ -133,10 +133,10 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         if (this.stopped) {
             return
         }
-        if (!areEqualNodeIds(contact.getPeerId().toNodeId(), this.config.localNodeId)) {
+        if (!areEqualNodeIds(contact.getNodeId(), this.config.localNodeId)) {
             // Important to lock here, before the ping result is known
             this.config.connectionManager?.weakLockConnection(contact.getPeerDescriptor())
-            if (this.connections.has(contact.getPeerId().toNodeId())) {
+            if (this.connections.has(contact.getNodeId())) {
                 logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
             } else {    // open connection by pinging
                 logger.trace('starting ping ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
@@ -246,7 +246,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             if (!excludeSet) {
                 return true
             } else {
-                return !excludeSet.has(contact.getPeerId().toNodeId())
+                return !excludeSet.has(contact.getNodeId())
             } 
         })
     }
@@ -264,7 +264,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             if (!excludeSet) {
                 return true
             } else {
-                return !excludeSet.has(contact.getPeerId().toNodeId())
+                return !excludeSet.has(contact.getNodeId())
             } 
         })
     }
@@ -274,7 +274,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             if (!excludeSet) {
                 return true
             } else {
-                return !excludeSet.has(contact.getPeerId().toNodeId())
+                return !excludeSet.has(contact.getNodeId())
             } 
         }).length
     }

--- a/packages/dht/src/dht/contact/Contact.ts
+++ b/packages/dht/src/dht/contact/Contact.ts
@@ -1,8 +1,9 @@
-import { PeerID } from '../../helpers/PeerID'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
-import { peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { NodeID } from '../../helpers/nodeId'
 
 export class Contact {
+
     private peerDescriptor: PeerDescriptor
 
     constructor(peerDescriptor: PeerDescriptor) {
@@ -13,7 +14,7 @@ export class Contact {
         return this.peerDescriptor
     }
 
-    public getPeerId(): PeerID {
-        return peerIdFromPeerDescriptor(this.peerDescriptor)
+    public getNodeId(): NodeID {
+        return getNodeIdFromPeerDescriptor(this.peerDescriptor)
     }
 }

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -1,4 +1,3 @@
-import { PeerID } from '../../helpers/PeerID'
 import EventEmitter from 'eventemitter3'
 import { NodeID } from '../../helpers/nodeId'
 
@@ -17,7 +16,7 @@ export interface Events<C> {
     newContact: (newContact: C, closestContacts: C[]) => void
 }
 
-export class ContactList<C extends { getPeerId: () => PeerID }> extends EventEmitter<Events<C>> {
+export class ContactList<C extends { getNodeId: () => NodeID }> extends EventEmitter<Events<C>> {
 
     protected contactsById: Map<NodeID, ContactState<C>> = new Map()
     // TODO move this to SortedContactList

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -1,5 +1,6 @@
-import { PeerID, PeerIDKey } from '../../helpers/PeerID'
+import { PeerID } from '../../helpers/PeerID'
 import EventEmitter from 'eventemitter3'
+import { NodeID } from '../../helpers/nodeId'
 
 export class ContactState<C> {
     public contacted = false
@@ -18,26 +19,26 @@ export interface Events<C> {
 
 export class ContactList<C extends { getPeerId: () => PeerID }> extends EventEmitter<Events<C>> {
 
-    protected contactsById: Map<PeerIDKey, ContactState<C>> = new Map()
+    protected contactsById: Map<NodeID, ContactState<C>> = new Map()
     // TODO move this to SortedContactList
-    protected contactIds: PeerID[] = []
-    protected ownId: PeerID
+    protected contactIds: NodeID[] = []
+    protected localNodeId: NodeID
     protected maxSize: number
     protected defaultContactQueryLimit
 
     constructor(
-        ownId: PeerID,
+        localNodeId: NodeID,
         maxSize: number,
         defaultContactQueryLimit = 20
     ) {
         super()
-        this.ownId = ownId
+        this.localNodeId = localNodeId
         this.maxSize = maxSize
         this.defaultContactQueryLimit = defaultContactQueryLimit
     }
 
-    public getContact(id: PeerID): ContactState<C> | undefined {
-        return this.contactsById.get(id.toKey())
+    public getContact(id: NodeID): ContactState<C> | undefined {
+        return this.contactsById.get(id)
     }
 
     public getSize(): number {

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -1,4 +1,5 @@
 import { PeerID } from '../../helpers/PeerID'
+import { NodeID, areEqualNodeIds } from '../../helpers/nodeId'
 import { ContactList, ContactState } from './ContactList'
 
 export class RandomContactList<C extends { getPeerId: () => PeerID }> extends ContactList<C> {
@@ -6,28 +7,28 @@ export class RandomContactList<C extends { getPeerId: () => PeerID }> extends Co
     private randomness: number
 
     constructor(
-        ownId: PeerID,
+        localNodeId: NodeID,
         maxSize: number,
         randomness = 0.20,
         defaultContactQueryLimit?: number
     ) {
-        super(ownId, maxSize, defaultContactQueryLimit)
+        super(localNodeId, maxSize, defaultContactQueryLimit)
         this.randomness = randomness
     }
 
     addContact(contact: C): void {
-        if (this.ownId.equals(contact.getPeerId())) {
+        if (areEqualNodeIds(this.localNodeId, contact.getPeerId().toNodeId())) {
             return
         }
-        if (!this.contactsById.has(contact.getPeerId().toKey())) {
+        if (!this.contactsById.has(contact.getPeerId().toNodeId())) {
             const roll = Math.random()
             if (roll < this.randomness) {
                 if (this.getSize() === this.maxSize && this.getSize() > 0) {
                     const toRemove = this.contactIds[0]
                     this.removeContact(toRemove)
                 }
-                this.contactIds.push(contact.getPeerId())
-                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
+                this.contactIds.push(contact.getPeerId().toNodeId())
+                this.contactsById.set(contact.getPeerId().toNodeId(), new ContactState(contact))
                 this.emit(
                     'newContact',
                     contact,
@@ -37,12 +38,12 @@ export class RandomContactList<C extends { getPeerId: () => PeerID }> extends Co
         }
     }
 
-    removeContact(id: PeerID): boolean {
-        if (this.contactsById.has(id.toKey())) {
-            const removed = this.contactsById.get(id.toKey())!.contact
-            const index = this.contactIds.findIndex((element) => element.equals(id))
+    removeContact(id: NodeID): boolean {
+        if (this.contactsById.has(id)) {
+            const removed = this.contactsById.get(id)!.contact
+            const index = this.contactIds.findIndex((nodeId) => areEqualNodeIds(nodeId, id))
             this.contactIds.splice(index, 1)
-            this.contactsById.delete(id.toKey())
+            this.contactsById.delete(id)
             this.emit('contactRemoved', removed, this.getContacts())
             return true
         }
@@ -52,7 +53,7 @@ export class RandomContactList<C extends { getPeerId: () => PeerID }> extends Co
     public getContacts(limit = this.defaultContactQueryLimit): C[] {
         const ret: C[] = []
         this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId.toKey())
+            const contact = this.contactsById.get(contactId)
             if (contact) {
                 ret.push(contact.contact)
             }

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -1,8 +1,7 @@
-import { PeerID } from '../../helpers/PeerID'
 import { NodeID, areEqualNodeIds } from '../../helpers/nodeId'
 import { ContactList, ContactState } from './ContactList'
 
-export class RandomContactList<C extends { getPeerId: () => PeerID }> extends ContactList<C> {
+export class RandomContactList<C extends { getNodeId: () => NodeID }> extends ContactList<C> {
 
     private randomness: number
 
@@ -17,18 +16,18 @@ export class RandomContactList<C extends { getPeerId: () => PeerID }> extends Co
     }
 
     addContact(contact: C): void {
-        if (areEqualNodeIds(this.localNodeId, contact.getPeerId().toNodeId())) {
+        if (areEqualNodeIds(this.localNodeId, contact.getNodeId())) {
             return
         }
-        if (!this.contactsById.has(contact.getPeerId().toNodeId())) {
+        if (!this.contactsById.has(contact.getNodeId())) {
             const roll = Math.random()
             if (roll < this.randomness) {
                 if (this.getSize() === this.maxSize && this.getSize() > 0) {
                     const toRemove = this.contactIds[0]
                     this.removeContact(toRemove)
                 }
-                this.contactIds.push(contact.getPeerId().toNodeId())
-                this.contactsById.set(contact.getPeerId().toNodeId(), new ContactState(contact))
+                this.contactIds.push(contact.getNodeId())
+                this.contactsById.set(contact.getNodeId(), new ContactState(contact))
                 this.emit(
                     'newContact',
                     contact,

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -1,27 +1,29 @@
-import { PeerID, PeerIDKey } from '../../helpers/PeerID'
+import { PeerID } from '../../helpers/PeerID'
 import { ContactState, Events } from './ContactList'
 import { sortedIndexBy } from 'lodash'
 import EventEmitter from 'eventemitter3'
 import { getDistance } from '../PeerManager'
+import { NodeID, areEqualNodeIds } from '../../helpers/nodeId'
+import { hexToBinary } from '@streamr/utils'
 
 export interface SortedContactListConfig {
-    referenceId: PeerID  // all contacts in this list are in sorted by the distance to this ID
+    referenceId: NodeID  // all contacts in this list are in sorted by the distance to this ID
     allowToContainReferenceId: boolean
     // TODO could maybe optimize this by removing the flag and then we'd check whether we have 
     // any listeners before we emit the event
     emitEvents: boolean
     maxSize?: number
     // if set, the list can't contain any contacts which are futher away than this limit
-    peerIdDistanceLimit?: PeerID
+    nodeIdDistanceLimit?: NodeID
     // if set, the list can't contain contacts with these ids
-    excludedPeerIDs?: PeerID[]
+    excludedNodeIDs?: NodeID[]
 }
 
 export class SortedContactList<C extends { getPeerId: () => PeerID }> extends EventEmitter<Events<C>> {
 
     private config: SortedContactListConfig
-    private contactsById: Map<PeerIDKey, ContactState<C>> = new Map()
-    private contactIds: PeerID[] = []
+    private contactsById: Map<NodeID, ContactState<C>> = new Map()
+    private contactIds: NodeID[] = []
 
     constructor(
         config: SortedContactListConfig
@@ -31,38 +33,40 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
         this.compareIds = this.compareIds.bind(this)
     }
 
-    public getClosestContactId(): PeerID {
+    public getClosestContactId(): NodeID {
         return this.contactIds[0]
     }
 
-    public getContactIds(): PeerID[] {
+    public getContactIds(): NodeID[] {
         return this.contactIds
     }
 
     public addContact(contact: C): void {
-        if (this.config.excludedPeerIDs !== undefined
-            && this.config.excludedPeerIDs.some((peerId) => contact.getPeerId().equals(peerId))) {
+        if (this.config.excludedNodeIDs !== undefined
+            && this.config.excludedNodeIDs.some((nodeId) => areEqualNodeIds(contact.getPeerId().toNodeId(), nodeId))) {
             return
         }
 
-        if ((!this.config.allowToContainReferenceId && this.config.referenceId.equals(contact.getPeerId())) ||
-            (this.config.peerIdDistanceLimit !== undefined && this.compareIds(this.config.peerIdDistanceLimit, contact.getPeerId()) < 0)) {
+        if ((!this.config.allowToContainReferenceId && areEqualNodeIds(this.config.referenceId, contact.getPeerId().toNodeId())) ||
+            (this.config.nodeIdDistanceLimit !== undefined && this.compareIds(this.config.nodeIdDistanceLimit, contact.getPeerId().toNodeId()) < 0)) {
             return
         }
-        if (!this.contactsById.has(contact.getPeerId().toKey())) {
+        if (!this.contactsById.has(contact.getPeerId().toNodeId())) {
             if ((this.config.maxSize === undefined) || (this.contactIds.length < this.config.maxSize)) {
-                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
+                this.contactsById.set(contact.getPeerId().toNodeId(), new ContactState(contact))
 
-                const index = sortedIndexBy(this.contactIds, contact.getPeerId(), (id: PeerID) => { return this.distanceToReferenceId(id) })
-                this.contactIds.splice(index, 0, contact.getPeerId())
-            } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contact.getPeerId()) > 0) {
+                // eslint-disable-next-line max-len
+                const index = sortedIndexBy(this.contactIds, contact.getPeerId().toNodeId(), (id: NodeID) => { return this.distanceToReferenceId(id) })
+                this.contactIds.splice(index, 0, contact.getPeerId().toNodeId())
+            } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contact.getPeerId().toNodeId()) > 0) {
                 const removedId = this.contactIds.pop()
-                const removedContact = this.contactsById.get(removedId!.toKey())!.contact
-                this.contactsById.delete(removedId!.toKey())
-                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
+                const removedContact = this.contactsById.get(removedId!)!.contact
+                this.contactsById.delete(removedId!)
+                this.contactsById.set(contact.getPeerId().toNodeId(), new ContactState(contact))
 
-                const index = sortedIndexBy(this.contactIds, contact.getPeerId(), (id: PeerID) => { return this.distanceToReferenceId(id) })
-                this.contactIds.splice(index, 0, contact.getPeerId())
+                // eslint-disable-next-line max-len
+                const index = sortedIndexBy(this.contactIds, contact.getPeerId().toNodeId(), (id: NodeID) => { return this.distanceToReferenceId(id) })
+                this.contactIds.splice(index, 0, contact.getPeerId().toNodeId())
                 if (this.config.emitEvents) {
                     this.emit(
                         'contactRemoved',
@@ -85,26 +89,26 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
         contacts.forEach((contact) => this.addContact(contact))
     }
 
-    public getContact(id: PeerID): ContactState<C> | undefined {
-        return this.contactsById.get(id.toKey())
+    public getContact(id: NodeID): ContactState<C> | undefined {
+        return this.contactsById.get(id)
     }
 
-    public setContacted(contactId: PeerID): void {
-        if (this.contactsById.has(contactId.toKey())) {
-            this.contactsById.get(contactId.toKey())!.contacted = true
+    public setContacted(contactId: NodeID): void {
+        if (this.contactsById.has(contactId)) {
+            this.contactsById.get(contactId)!.contacted = true
         }
     }
 
-    public setActive(contactId: PeerID): void {
-        if (this.contactsById.has(contactId.toKey())) {
-            this.contactsById.get(contactId.toKey())!.active = true
+    public setActive(contactId: NodeID): void {
+        if (this.contactsById.has(contactId)) {
+            this.contactsById.get(contactId)!.active = true
         }
     }
 
     public getClosestContacts(limit?: number): C[] {
         const ret: C[] = []
         this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId.toKey())
+            const contact = this.contactsById.get(contactId)
             if (contact) {
                 ret.push(contact.contact)
             }
@@ -119,7 +123,7 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
     public getUncontactedContacts(num: number): C[] {
         const ret: C[] = []
         for (const contactId of this.contactIds) {
-            const contact = this.contactsById.get(contactId.toKey())
+            const contact = this.contactsById.get(contactId)
             if (contact && !contact.contacted) {
                 ret.push(contact.contact)
                 if (ret.length >= num) {
@@ -133,7 +137,7 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
     public getActiveContacts(limit?: number): C[] {
         const ret: C[] = []
         this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId.toKey())
+            const contact = this.contactsById.get(contactId)
             if (contact && contact.active) {
                 ret.push(contact.contact)
             }
@@ -145,23 +149,25 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
         }
     }
 
-    public compareIds(id1: PeerID, id2: PeerID): number {
+    public compareIds(id1: NodeID, id2: NodeID): number {
         const distance1 = this.distanceToReferenceId(id1)
         const distance2 = this.distanceToReferenceId(id2)
         return distance1 - distance2
     }
 
     // TODO inline this method?
-    private distanceToReferenceId(id: PeerID): number {
-        return getDistance(this.config.referenceId.value, id.value)
+    private distanceToReferenceId(id: NodeID): number {
+        // TODO maybe this class should store the referenceId also as UInt8Array so that we don't need to convert it here?
+        return getDistance(hexToBinary(this.config.referenceId), hexToBinary(id))
     }
 
-    public removeContact(id: PeerID): boolean {
-        if (this.contactsById.has(id.toKey())) {
-            const removed = this.contactsById.get(id.toKey())!.contact
-            const index = this.contactIds.findIndex((element) => element.equals(id))
+    public removeContact(id: NodeID): boolean {
+        if (this.contactsById.has(id)) {
+            const removed = this.contactsById.get(id)!.contact
+            // TODO use sortedIndexBy?
+            const index = this.contactIds.findIndex((nodeId) => areEqualNodeIds(nodeId, id))
             this.contactIds.splice(index, 1)
-            this.contactsById.delete(id.toKey())
+            this.contactsById.delete(id)
             if (this.config.emitEvents) {
                 this.emit(
                     'contactRemoved',
@@ -174,12 +180,12 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
         return false
     }
 
-    public isActive(id: PeerID): boolean {
-        return this.contactsById.has(id.toKey()) ? this.contactsById.get(id.toKey())!.active : false
+    public isActive(id: NodeID): boolean {
+        return this.contactsById.has(id) ? this.contactsById.get(id)!.active : false
     }
 
     public getAllContacts(): C[] {
-        return this.contactIds.map((peerId) => this.contactsById.get(peerId.toKey())!.contact)
+        return this.contactIds.map((nodeId) => this.contactsById.get(nodeId)!.contact)
     }
 
     public getSize(): number {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -4,7 +4,6 @@ import { sortedIndexBy } from 'lodash'
 import EventEmitter from 'eventemitter3'
 import { getDistance } from '../PeerManager'
 import { NodeID, areEqualNodeIds } from '../../helpers/nodeId'
-import { hexToBinary } from '@streamr/utils'
 
 export interface SortedContactListConfig {
     referenceId: NodeID  // all contacts in this list are in sorted by the distance to this ID
@@ -158,7 +157,7 @@ export class SortedContactList<C extends { getPeerId: () => PeerID }> extends Ev
     // TODO inline this method?
     private distanceToReferenceId(id: NodeID): number {
         // TODO maybe this class should store the referenceId also as UInt8Array so that we don't need to convert it here?
-        return getDistance(hexToBinary(this.config.referenceId), hexToBinary(id))
+        return getDistance(this.config.referenceId, id)
     }
 
     public removeContact(id: NodeID): boolean {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -14,7 +14,7 @@ export interface SortedContactListConfig {
     // if set, the list can't contain any contacts which are futher away than this limit
     nodeIdDistanceLimit?: NodeID
     // if set, the list can't contain contacts with these ids
-    excludedNodeIDs?: NodeID[]
+    excludedNodeIDs?: Set<NodeID>
 }
 
 export class SortedContactList<C extends { getNodeId: () => NodeID }> extends EventEmitter<Events<C>> {
@@ -40,8 +40,7 @@ export class SortedContactList<C extends { getNodeId: () => NodeID }> extends Ev
     }
 
     public addContact(contact: C): void {
-        if (this.config.excludedNodeIDs !== undefined
-            && this.config.excludedNodeIDs.some((nodeId) => areEqualNodeIds(contact.getNodeId(), nodeId))) {
+        if (this.config.excludedNodeIDs !== undefined && this.config.excludedNodeIDs.has(contact.getNodeId())) {
             return
         }
 

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -48,9 +48,9 @@ export class DiscoverySession {
         }
         logger.trace(`Getting closest peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
         this.outgoingClosestPeersRequestsCounter++
-        this.contactedPeers.add(contact.getPeerId().toNodeId())
+        this.contactedPeers.add(contact.getNodeId())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
-        this.config.peerManager.handlePeerActive(contact.getPeerId().toNodeId())
+        this.config.peerManager.handlePeerActive(contact.getNodeId())
         return returnedContacts
     }
 
@@ -60,10 +60,10 @@ export class DiscoverySession {
         }
         this.ongoingClosestPeersRequests.delete(nodeId)
         const oldClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(getNodeIdFromBinary(this.config.targetId), 1)[0]
-        const oldClosestDistance = getDistance(getNodeIdFromBinary(this.config.targetId), oldClosestNeighbor.getPeerId().toNodeId())
+        const oldClosestDistance = getDistance(getNodeIdFromBinary(this.config.targetId), oldClosestNeighbor.getNodeId())
         this.addNewContacts(contacts)
         const newClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(getNodeIdFromBinary(this.config.targetId), 1)[0]
-        const newClosestDistance = getDistance(getNodeIdFromBinary(this.config.targetId), newClosestNeighbor.getPeerId().toNodeId())
+        const newClosestDistance = getDistance(getNodeIdFromBinary(this.config.targetId), newClosestNeighbor.getNodeId())
         if (newClosestDistance >= oldClosestDistance) {
             this.noProgressCounter++
         } else {
@@ -72,11 +72,11 @@ export class DiscoverySession {
     }
 
     private onClosestPeersRequestFailed(peer: DhtNodeRpcRemote) {
-        if (!this.ongoingClosestPeersRequests.has(peer.getPeerId().toNodeId())) {
+        if (!this.ongoingClosestPeersRequests.has(peer.getNodeId())) {
             return
         }
-        this.ongoingClosestPeersRequests.delete(peer.getPeerId().toNodeId())
-        this.config.peerManager.handlePeerUnresponsive(peer.getPeerId().toNodeId())
+        this.ongoingClosestPeersRequests.delete(peer.getNodeId())
+        this.config.peerManager.handlePeerUnresponsive(peer.getNodeId())
     }
 
     private findMoreContacts(): void {
@@ -97,10 +97,10 @@ export class DiscoverySession {
             if (this.ongoingClosestPeersRequests.size >= this.config.parallelism) {
                 break
             }
-            this.ongoingClosestPeersRequests.add(nextPeer.getPeerId().toNodeId())
+            this.ongoingClosestPeersRequests.add(nextPeer.getNodeId())
             // eslint-disable-next-line promise/catch-or-return
             this.getClosestPeersFromContact(nextPeer)
-                .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer.getPeerId().toNodeId(), contacts))
+                .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer.getNodeId(), contacts))
                 .catch(() => this.onClosestPeersRequestFailed(nextPeer))
                 .finally(() => {
                     this.outgoingClosestPeersRequestsCounter--

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -127,7 +127,10 @@ export class PeerDiscovery {
         if (this.isStopped()) {
             return
         }
-        const nodes = this.config.peerManager.getClosestNeighborsTo(this.config.localPeerDescriptor.nodeId, this.config.parallelism)
+        const nodes = this.config.peerManager.getClosestNeighborsTo(
+            getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor),
+            this.config.parallelism
+        )
         await Promise.allSettled(
             nodes.map(async (peer: DhtNodeRpcRemote) => {
                 const contacts = await peer.getClosestPeers(this.config.localPeerDescriptor.nodeId!)

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -112,7 +112,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
             serviceId: sessionId,
             transport: this.sessionTransport,
             targetId,
-            localPeerId: peerIdFromPeerDescriptor(this.localPeerDescriptor),
+            localNodeId: getNodeIdFromPeerDescriptor(this.localPeerDescriptor),
             // TODO use config option or named constant?
             waitedRoutingPathCompletions: this.connections.size > 1 ? 2 : 1,
             operation

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -30,12 +30,12 @@ import { getPreviousPeer } from '../routing/getPreviousPeer'
 import { createRouteMessageAck } from '../routing/RouterRpcLocal'
 import { ServiceID } from '../../types/ServiceID'
 import { RecursiveOperationRpcLocal } from './RecursiveOperationRpcLocal'
-import { getNodeIdFromBinary } from '../../helpers/nodeId'
+import { NodeID, getNodeIdFromBinary } from '../../helpers/nodeId'
 
 interface RecursiveOperationManagerConfig {
     rpcCommunicator: RoutingRpcCommunicator
     sessionTransport: ITransport
-    connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    connections: Map<NodeID, DhtNodeRpcRemote>
     router: IRouter
     localPeerDescriptor: PeerDescriptor
     serviceId: ServiceID
@@ -56,7 +56,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
 
     private readonly rpcCommunicator: RoutingRpcCommunicator
     private readonly sessionTransport: ITransport
-    private readonly connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    private readonly connections: Map<NodeID, DhtNodeRpcRemote>
     private readonly router: IRouter
     private readonly localPeerDescriptor: PeerDescriptor
     private readonly serviceId: ServiceID

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -10,10 +10,10 @@ import {
     RouteMessageError,
     RouteMessageWrapper
 } from '../../proto/packages/dht/protos/DhtRpc'
-import { PeerID, PeerIDKey } from '../../helpers/PeerID'
+import { PeerID } from '../../helpers/PeerID'
 import { IRouter } from '../routing/Router'
 import { RoutingMode } from '../routing/RoutingSession'
-import { areEqualPeerDescriptors, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Logger, runAndWaitForEvents3, wait } from '@streamr/utils'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { RecursiveOperationSessionRpcRemote } from './RecursiveOperationSessionRpcRemote'
@@ -152,7 +152,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
                 this.sendResponse([], this.localPeerDescriptor, sessionId, [], data, true)
             }
         } else if (operation === RecursiveOperation.DELETE_DATA) {
-            this.localDataStore.markAsDeleted(targetId, peerIdFromPeerDescriptor(this.localPeerDescriptor))
+            this.localDataStore.markAsDeleted(targetId, getNodeIdFromPeerDescriptor(this.localPeerDescriptor))
         }
         this.ongoingSessions.delete(sessionId)
         session.stop()
@@ -193,7 +193,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
         targetPeerDescriptor: PeerDescriptor,
         serviceId: ServiceID,
         closestNodes: PeerDescriptor[],
-        data: Map<PeerIDKey, DataEntry> | undefined,
+        data: Map<NodeID, DataEntry> | undefined,
         noCloserNodesFound: boolean = false
     ): void {
         const dataEntries = data ? Array.from(data.values(), DataEntry.create.bind(DataEntry)) : []
@@ -230,7 +230,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
             ? this.localDataStore.getEntries(targetId.value) 
             : undefined
         if (recursiveOperationRequest!.operation === RecursiveOperation.DELETE_DATA) {
-            this.localDataStore.markAsDeleted(targetId.value, peerIdFromPeerDescriptor(routedMessage.sourcePeer!))
+            this.localDataStore.markAsDeleted(targetId.value, getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!))
         }
         if (areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.destinationPeer!)) {
             // TODO this is also very similar case to what we do at line 255, could simplify the code paths?

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -30,6 +30,7 @@ import { getPreviousPeer } from '../routing/getPreviousPeer'
 import { createRouteMessageAck } from '../routing/RouterRpcLocal'
 import { ServiceID } from '../../types/ServiceID'
 import { RecursiveOperationRpcLocal } from './RecursiveOperationRpcLocal'
+import { getNodeIdFromBinary } from '../../helpers/nodeId'
 
 interface RecursiveOperationManagerConfig {
     rpcCommunicator: RoutingRpcCommunicator
@@ -267,7 +268,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
     private getClosestConnections(nodeId: Uint8Array, limit: number): PeerDescriptor[] {
         const connectedPeers = Array.from(this.connections.values())
         const closestPeers = new SortedContactList<DhtNodeRpcRemote>({
-            referenceId: PeerID.fromValue(nodeId),
+            referenceId: getNodeIdFromBinary(nodeId),
             maxSize: limit,
             allowToContainReferenceId: true,
             emitEvents: false

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -9,6 +9,7 @@ import { RecursiveOperationResult } from './RecursiveOperationManager'
 import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { ServiceID } from '../../types/ServiceID'
 import { RecursiveOperationSessionRpcLocal } from './RecursiveOperationSessionRpcLocal'
+import { getNodeIdFromBinary } from '../../helpers/nodeId'
 
 export interface RecursiveOperationSessionEvents {
     completed: (results: PeerDescriptor[]) => void
@@ -47,7 +48,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         this.localPeerId = config.localPeerId
         this.waitedRoutingPathCompletions = config.waitedRoutingPathCompletions
         this.results = new SortedContactList({
-            referenceId: PeerID.fromValue(this.targetId), 
+            referenceId: getNodeIdFromBinary(this.targetId), 
             maxSize: 10,  // TODO use config option or named constant?
             allowToContainReferenceId: true,
             emitEvents: false

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -1,8 +1,7 @@
 import { Message, PeerDescriptor, RouteMessageAck, RouteMessageError, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
 import {
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor,
-    peerIdFromPeerDescriptor
+    getNodeIdFromPeerDescriptor
 } from '../../helpers/peerIdFromPeerDescriptor'
 import { RoutingMode, RoutingSession, RoutingSessionEvents } from './RoutingSession'
 import { Logger, executeSafePromise, raceEvents3, withTimeout } from '@streamr/utils'
@@ -170,10 +169,10 @@ export class Router implements IRouter {
         }
     }
 
-    private createRoutingSession(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RoutingSession {
-        const excludedPeers = routedMessage.routingPath.map((descriptor) => peerIdFromPeerDescriptor(descriptor))
-        if (excludedPeer) {
-            excludedPeers.push(peerIdFromPeerDescriptor(excludedPeer))
+    private createRoutingSession(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedNode?: PeerDescriptor): RoutingSession {
+        const excludedPeers = routedMessage.routingPath.map((descriptor) => getNodeIdFromPeerDescriptor(descriptor))
+        if (excludedNode) {
+            excludedPeers.push(getNodeIdFromPeerDescriptor(excludedNode))
         }
         logger.trace('routing session created with connections: ' + this.connections.size)
         return new RoutingSession(

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -170,9 +170,9 @@ export class Router implements IRouter {
     }
 
     private createRoutingSession(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedNode?: PeerDescriptor): RoutingSession {
-        const excludedPeers = routedMessage.routingPath.map((descriptor) => getNodeIdFromPeerDescriptor(descriptor))
+        const excludedPeers = new Set<NodeID>(routedMessage.routingPath.map((descriptor) => getNodeIdFromPeerDescriptor(descriptor)))
         if (excludedNode) {
-            excludedPeers.push(getNodeIdFromPeerDescriptor(excludedNode))
+            excludedPeers.add(getNodeIdFromPeerDescriptor(excludedNode))
         }
         logger.trace('routing session created with connections: ' + this.connections.size)
         return new RoutingSession(

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -14,11 +14,12 @@ import { ConnectionManager } from '../../connection/ConnectionManager'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { v4 } from 'uuid'
 import { RouterRpcLocal, createRouteMessageAck } from './RouterRpcLocal'
+import { NodeID } from '../../helpers/nodeId'
 
 export interface RouterConfig {
     rpcCommunicator: RoutingRpcCommunicator
     localPeerDescriptor: PeerDescriptor
-    connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    connections: Map<NodeID, DhtNodeRpcRemote>
     addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     connectionManager?: ConnectionManager
     rpcRequestTimeout?: number
@@ -45,7 +46,7 @@ const logger = new Logger(module)
 export class Router implements IRouter {
     private readonly rpcCommunicator: RoutingRpcCommunicator
     private readonly localPeerDescriptor: PeerDescriptor
-    private readonly connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    private readonly connections: Map<NodeID, DhtNodeRpcRemote>
     private readonly forwardingTable: Map<PeerIDKey, ForwardingTableEntry> = new Map()
     private ongoingRoutingSessions: Map<string, RoutingSession> = new Map()
     // TODO use config option or named constant?

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -1,6 +1,5 @@
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { SortedContactList } from '../contact/SortedContactList'
-import { PeerID } from '../../helpers/PeerID'
 import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
@@ -88,7 +87,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         connections: Map<NodeID, DhtNodeRpcRemote>,
         parallelism: number,
         mode: RoutingMode = RoutingMode.ROUTE,
-        excludedPeerIDs?: PeerID[]
+        excludedNodeIDs?: NodeID[]
     ) {
         super()
         this.rpcCommunicator = rpcCommunicator
@@ -104,7 +103,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             maxSize: 10000,  // TODO use config option or named constant?
             allowToContainReferenceId: true,
             nodeIdDistanceLimit: previousId,
-            excludedNodeIDs: excludedPeerIDs?.map((p) => p.toNodeId()),
+            excludedNodeIDs,
             emitEvents: false
         })
     }

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -14,6 +14,7 @@ import { Contact } from '../contact/Contact'
 import { RecursiveOperationRpcRemote } from '../recursive-operation/RecursiveOperationRpcRemote'
 import { EXISTING_CONNECTION_TIMEOUT } from '../contact/RpcRemote'
 import { getPreviousPeer } from './getPreviousPeer'
+import { NodeID } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -73,7 +74,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
     private contactList: SortedContactList<RemoteContact>
     private readonly localPeerDescriptor: PeerDescriptor
     private readonly messageToRoute: RouteMessageWrapper
-    private connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    private connections: Map<NodeID, DhtNodeRpcRemote>
     private readonly parallelism: number
     private failedHopCounter = 0
     private successfulHopCounter = 0
@@ -84,7 +85,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         rpcCommunicator: RoutingRpcCommunicator,
         localPeerDescriptor: PeerDescriptor,
         messageToRoute: RouteMessageWrapper,
-        connections: Map<PeerIDKey, DhtNodeRpcRemote>,
+        connections: Map<NodeID, DhtNodeRpcRemote>,
         parallelism: number,
         mode: RoutingMode = RoutingMode.ROUTE,
         excludedPeerIDs?: PeerID[]
@@ -175,7 +176,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         // Remove stale contacts that may have been removed from connections
         this.contactList.getAllContacts().forEach((contact) => {
             const peerId = peerIdFromPeerDescriptor(contact.getPeerDescriptor())
-            if (this.connections.has(peerId.toKey()) === false) {
+            if (this.connections.has(peerId.toNodeId()) === false) {
                 this.contactList.removeContact(peerId.toNodeId())
             }
         })

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -87,7 +87,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         connections: Map<NodeID, DhtNodeRpcRemote>,
         parallelism: number,
         mode: RoutingMode = RoutingMode.ROUTE,
-        excludedNodeIDs?: NodeID[]
+        excludedNodeIDs?: Set<NodeID>
     ) {
         super()
         this.rpcCommunicator = rpcCommunicator

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -22,7 +22,7 @@ const MAX_FAILED_HOPS = 2
 class RemoteContact extends Contact {
 
     private routerRpcRemote: RouterRpcRemote
-    private RecursiveOperationRpcRemote: RecursiveOperationRpcRemote
+    private recursiveOperationRpcRemote: RecursiveOperationRpcRemote
 
     constructor(peer: DhtNodeRpcRemote, localPeerDescriptor: PeerDescriptor, rpcCommunicator: RoutingRpcCommunicator) {
         super(peer.getPeerDescriptor())
@@ -33,7 +33,7 @@ class RemoteContact extends Contact {
             toProtoRpcClient(new RouterRpcClient(rpcCommunicator.getRpcClientTransport())),
             EXISTING_CONNECTION_TIMEOUT
         )
-        this.RecursiveOperationRpcRemote = new RecursiveOperationRpcRemote(
+        this.recursiveOperationRpcRemote = new RecursiveOperationRpcRemote(
             localPeerDescriptor,
             peer.getPeerDescriptor(),
             peer.getServiceId(),
@@ -47,7 +47,7 @@ class RemoteContact extends Contact {
     }
 
     getRecursiveOperationRpcRemote(): RecursiveOperationRpcRemote {
-        return this.RecursiveOperationRpcRemote
+        return this.recursiveOperationRpcRemote
     }
 }
 

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -204,15 +204,15 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             const nextPeer = uncontacted.shift()
             // eslint-disable-next-line max-len
             logger.trace(`Sending routeMessage request to contact: ${getNodeIdFromPeerDescriptor(nextPeer!.getPeerDescriptor())} (sessionId=${this.sessionId})`)
-            this.contactList.setContacted(nextPeer!.getPeerId().toNodeId())
-            this.ongoingRequests.add(nextPeer!.getPeerId().toNodeId())
+            this.contactList.setContacted(nextPeer!.getNodeId())
+            this.ongoingRequests.add(nextPeer!.getNodeId())
             setImmediate(async () => {
                 try {
                     const succeeded = await this.sendRouteMessageRequest(nextPeer!)
                     if (succeeded) {
                         this.onRequestSucceeded()
                     } else {
-                        this.onRequestFailed(nextPeer!.getPeerId().toNodeId())
+                        this.onRequestFailed(nextPeer!.getNodeId())
                     }
                 } catch (e) {
                     logger.debug('Unable to route message ', { error: e })

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -10,7 +10,7 @@ import { toProtoRpcClient } from '@streamr/proto-rpc'
 import { StoreRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { IRecursiveOperationManager } from '../recursive-operation/RecursiveOperationManager'
-import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Logger, executeSafePromise } from '@streamr/utils'
 import { LocalDataStore } from './LocalDataStore'
 import { IStoreRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
@@ -106,7 +106,7 @@ export class StoreRpcLocal implements IStoreRpc {
                 }
             }
         } else if (!this.selfIsOneOfClosestPeers(dataEntry.key)) {
-            this.localDataStore.setStale(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!), true)
+            this.localDataStore.setStale(dataEntry.key, getNodeIdFromPeerDescriptor(dataEntry.creator!), true)
         }
     }
 

--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -2,6 +2,7 @@ import { BrandedString, binaryToHex } from '@streamr/utils'
 import { UUID } from './UUID'
 import { IllegalArguments } from './errors'
 import crypto from 'crypto'
+import { NodeID, getNodeIdFromBinary } from './nodeId'
 
 export type PeerIDKey = BrandedString<'PeerIDKey'>
 
@@ -73,6 +74,10 @@ export class PeerID {
 
     toKey(): PeerIDKey {
         return this.key
+    }
+
+    toNodeId(): NodeID {
+        return getNodeIdFromBinary(this.data)
     }
 
     get value(): Uint8Array {

--- a/packages/dht/src/helpers/nodeId.ts
+++ b/packages/dht/src/helpers/nodeId.ts
@@ -1,8 +1,28 @@
+import { BrandedString, binaryToHex } from '@streamr/utils'
 import crypto from 'crypto'
 
 // https://www.scs.stanford.edu/~dm/home/papers/kpos.pdf
 const KADEMLIA_ID_LENGTH_IN_BYTES = 20
 
+// TODO this should return NodeID
 export const createRandomNodeId = (): Uint8Array => {
     return crypto.randomBytes(KADEMLIA_ID_LENGTH_IN_BYTES)
+}
+
+// TODO rename the file to be "NodeID.ts" instead of "nodeId.ts"
+export type NodeID = BrandedString<'NodeID'>
+
+// TODO remove this or add support for UInt8Array parameters
+export const areEqualNodeIds = (nodeId1: NodeID, nodeId2: NodeID): boolean => {
+    return nodeId1 === nodeId2
+}
+
+// TODO maybe this is not needed and we can use just getNodeIdFromBinary?
+export const getNodeIdFromDataKey = (key: Uint8Array): NodeID => {
+    return getNodeIdFromBinary(key)
+}
+
+// TODO should we have similar method to convert nodeId to bucketId (which is just hexToBinary)
+export const getNodeIdFromBinary = (id: Uint8Array): NodeID => {
+    return binaryToHex(id) as unknown as NodeID
 }

--- a/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
+++ b/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
@@ -1,14 +1,16 @@
 import { areEqualBinaries, binaryToHex } from '@streamr/utils'
 import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { PeerID, PeerIDKey, createPeerIDKey } from './PeerID'
+import { NodeID } from './nodeId'
 
 export const peerIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerID => {
     return PeerID.fromValue(peerDescriptor.nodeId)
 }
 
-// TODO could move getNodeIdFromPeerDescriptor (and NodeID) from trackerless-network
-export const getNodeIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): string => {
-    return binaryToHex(peerDescriptor.nodeId)
+// TODO could use this in trackerless-network (instead of copy-pasted same implementation)
+// and move this to nodeId.ts
+export const getNodeIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): NodeID => {
+    return binaryToHex(peerDescriptor.nodeId) as unknown as NodeID
 }
 
 export const keyFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerIDKey => {

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import { PeerID } from '../../src/helpers/PeerID'
 import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { Logger, wait } from '@streamr/utils'
+import { Logger, hexToBinary, wait } from '@streamr/utils'
 import { debugVars } from '../../src/helpers/debugHelpers'
 
 const logger = new Logger(module)
@@ -18,8 +18,6 @@ describe('Find correctness', () => {
     let entrypointDescriptor: PeerDescriptor
     const simulator = new Simulator(LatencyType.NONE)
     const NUM_NODES = 1000
-
-    const nodeIndicesById: Record<string, number> = {}
 
     if (!fs.existsSync('test/data/nodeids.json')) {
         console.log('ground truth data does not exist yet, generating..')
@@ -34,9 +32,8 @@ describe('Find correctness', () => {
         const entryPointId = '0'
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, Uint8Array.from(dhtIds[0].data), undefined)
         nodes.push(entryPoint)
-        nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
-            nodeId: entryPoint.getNodeId().value,
+            nodeId: hexToBinary(entryPoint.getNodeId()),
             type: NodeType.NODEJS
         }
 
@@ -44,7 +41,6 @@ describe('Find correctness', () => {
             const nodeId = `${i}`
 
             const node = await createMockConnectionDhtNode(nodeId, simulator, Uint8Array.from(dhtIds[i].data), undefined)
-            nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }
     })

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -2,21 +2,20 @@
 
 import KBucket from 'k-bucket'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
-import { PeerID } from '../../src/helpers/PeerID'
 import crypto from 'crypto'
-import { getNodeIdFromBinary } from '../../src/helpers/nodeId'
+import { NodeID, getNodeIdFromBinary } from '../../src/helpers/nodeId'
 
 const NUM_ADDS = 1000
 interface Item {
     id: Uint8Array
     vectorClock: number
-    getPeerId: () => PeerID
+    getNodeId: () => NodeID
 }
 
 const createRandomItem = (index: number): Item => {
     const rand = new Uint8Array(crypto.randomBytes(20))
     return {
-        getPeerId: () => PeerID.fromValue(rand),
+        getNodeId: () => getNodeIdFromBinary(rand),
         id: rand,
         vectorClock: index
     }

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -4,6 +4,7 @@ import KBucket from 'k-bucket'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { PeerID } from '../../src/helpers/PeerID'
 import crypto from 'crypto'
+import { getNodeIdFromBinary } from '../../src/helpers/nodeId'
 
 const NUM_ADDS = 1000
 interface Item {
@@ -37,7 +38,7 @@ describe('SortedContactListBenchmark', () => {
             randomIds.push(createRandomItem(i))
         }
         const list = new SortedContactList({
-            referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+            referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
             allowToContainReferenceId: true,
             emitEvents: true
         })
@@ -49,7 +50,7 @@ describe('SortedContactListBenchmark', () => {
         console.timeEnd('SortedContactList.addContact() with emitEvents=true')
 
         const list2 = new SortedContactList({
-            referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+            referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
             allowToContainReferenceId: true,
             emitEvents: false
         })
@@ -83,7 +84,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=true')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+                referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
                 allowToContainReferenceId: true,
                 emitEvents: true
             })
@@ -97,7 +98,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+                referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })
@@ -111,7 +112,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false and lodash')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+                referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })
@@ -125,7 +126,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false and addContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: PeerID.fromValue(crypto.randomBytes(20)),
+                referenceId: getNodeIdFromBinary(crypto.randomBytes(20)),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })

--- a/packages/dht/test/benchmark/kademlia-simulation/Contact.ts
+++ b/packages/dht/test/benchmark/kademlia-simulation/Contact.ts
@@ -1,32 +1,33 @@
-import { PeerID } from '../../../src/helpers/PeerID'
 import type { SimulationNode } from './SimulationNode'
 import { NodeType, PeerDescriptor } from '../../../src/proto/packages/dht/protos/DhtRpc'
+import { NodeID } from '../../../src/helpers/nodeId'
+import { hexToBinary } from '@streamr/utils'
 
 export class Contact {
     private static counter = 0
 
-    public peerId: PeerID
+    public ownId: NodeID
     public id: Uint8Array
     public vectorClock = 0
     public dhtNode: SimulationNode | undefined
 
-    constructor(ownId: PeerID, dhtNode?: SimulationNode) {
-        this.peerId = ownId
+    constructor(ownId: NodeID, dhtNode?: SimulationNode) {
+        this.ownId = ownId
         this.vectorClock = Contact.counter++
         this.dhtNode = dhtNode
-        this.id = ownId.value
+        this.id = hexToBinary(ownId)
     }
 
     getPeerDescriptor(): PeerDescriptor {
         const peerDescriptor: PeerDescriptor = {
-            nodeId: this.peerId.value,
+            nodeId: hexToBinary(this.ownId),
             type: NodeType.NODEJS
         }
         return peerDescriptor
     }
 
-    getPeerId(): PeerID {
-        return this.peerId
+    getNodeId(): NodeID {
+        return this.ownId
     }
 
 }

--- a/packages/dht/test/benchmark/kademlia-simulation/KademliaSimulation.ts
+++ b/packages/dht/test/benchmark/kademlia-simulation/KademliaSimulation.ts
@@ -2,7 +2,7 @@
 
 import { SimulationNode } from './SimulationNode'
 import fs from 'fs'
-import { PeerID } from '../../../src/helpers/PeerID'
+import { getNodeIdFromBinary } from '../../../src/helpers/nodeId'
 
 export class KademliaSimulation {
     
@@ -25,7 +25,7 @@ export class KademliaSimulation {
 
     public run(): void {
         for (let i = 0; i < KademliaSimulation.NUM_NODES; i++) {
-            const node = new SimulationNode(PeerID.fromValue(Buffer.from(this.dhtIds[i].data.slice(0, KademliaSimulation.ID_LENGTH))))
+            const node = new SimulationNode(getNodeIdFromBinary(Buffer.from(this.dhtIds[i].data.slice(0, KademliaSimulation.ID_LENGTH))))
             this.nodeNamesById[JSON.stringify(node.getContact().id)] = i
             this.nodes.push(node)
             node.joinDht(this.nodes[0])

--- a/packages/dht/test/benchmark/kademlia-simulation/SimulationNode.ts
+++ b/packages/dht/test/benchmark/kademlia-simulation/SimulationNode.ts
@@ -2,6 +2,7 @@ import KBucket from 'k-bucket'
 import { Contact } from './Contact'
 import { SortedContactList } from '../../../src/dht/contact/SortedContactList'
 import { PeerID } from '../../../src/helpers/PeerID'
+import { areEqualNodeIds } from '../../../src/helpers/nodeId'
 
 export class SimulationNode {
 
@@ -27,7 +28,7 @@ export class SimulationNode {
         })
 
         this.neighborList = new SortedContactList({ 
-            referenceId: this.ownId, 
+            referenceId: this.ownId.toNodeId(),
             maxSize: 1000,
             allowToContainReferenceId: false,
             emitEvents: false
@@ -72,8 +73,8 @@ export class SimulationNode {
 
     private findMoreContacts(contactList: Contact[], shortlist: SortedContactList<Contact>) {
         contactList.forEach((contact) => {
-            shortlist.setContacted(contact.peerId)
-            shortlist.setActive(contact.peerId)
+            shortlist.setContacted(contact.peerId.toNodeId())
+            shortlist.setActive(contact.peerId.toNodeId())
             this.numberOfOutgoingRpcCalls++
             const returnedContacts = contact.dhtNode!.getClosestNodesTo(this.ownId, this)
             shortlist.addContacts(returnedContacts)
@@ -105,7 +106,7 @@ export class SimulationNode {
 
             this.findMoreContacts(uncontacted, this.neighborList)
 
-            if (oldClosestContactId.equals(this.neighborList.getClosestContactId())) {
+            if (areEqualNodeIds(oldClosestContactId, this.neighborList.getClosestContactId())) {
                 uncontacted = this.neighborList.getUncontactedContacts(this.K)
                 if (uncontacted.length === 0) {
                     return
@@ -116,7 +117,7 @@ export class SimulationNode {
                     this.findMoreContacts(uncontacted, this.neighborList)
 
                     if (this.neighborList.getActiveContacts().length >= this.K ||
-                        oldClosestContactId.equals(this.neighborList.getClosestContactId())) {
+                        areEqualNodeIds(oldClosestContactId, this.neighborList.getClosestContactId())) {
                         return
                     }
                     uncontacted = this.neighborList.getUncontactedContacts(this.ALPHA)

--- a/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
+++ b/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
@@ -1,3 +1,4 @@
+import { hexToBinary } from '@streamr/utils'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
 import { DhtNode } from '../../src/dht/DhtNode'
@@ -11,7 +12,7 @@ const runTest = async (latencyType: LatencyType) => {
     const entryPointId = '0'
     const entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, undefined, NUM_OF_NODES_PER_KBUCKET)
     const entrypointDescriptor = {
-        nodeId: entryPoint.getNodeId().value,
+        nodeId: hexToBinary(entryPoint.getNodeId()),
         type: NodeType.NODEJS,
         region: getRandomRegion()
     }

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -4,6 +4,7 @@ import { PeerDescriptor, RecursiveOperation } from '../../src/proto/packages/dht
 import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
 import { PeerID } from '../../src/helpers/PeerID'
 import { peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { hexToBinary } from '@streamr/utils'
 
 describe('Find correctness', () => {
 
@@ -38,7 +39,7 @@ describe('Find correctness', () => {
     })
 
     it('Entrypoint can find a node from the network (exact match)', async () => {
-        const targetId = nodes[45].getNodeId().value
+        const targetId = hexToBinary(nodes[45].getNodeId())
         const results = await entryPoint.executeRecursiveOperation(targetId, RecursiveOperation.FIND_NODE)
         expect(results.closestNodes.length).toBeGreaterThanOrEqual(5)
         expect(PeerID.fromValue(targetId).equals(peerIdFromPeerDescriptor(results.closestNodes[0])))

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -4,6 +4,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node } from '../utils/utils'
 import { UUID } from '../../src/helpers/UUID'
 import { NodeType } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { areEqualNodeIds } from '../../src/helpers/nodeId'
 
 const NUM_OF_NODES_PER_KBUCKET = 8
 
@@ -73,7 +74,7 @@ describe('Layer1', () => {
         for (let i = 0; i < NODE_COUNT; i++) {
             const layer0Node = nodes[i]
             const layer1Node = layer1Nodes[i]
-            expect(layer1Node.getNodeId().equals(layer0Node.getNodeId())).toEqual(true)
+            expect(areEqualNodeIds(layer1Node.getNodeId(), layer0Node.getNodeId())).toEqual(true)
             expect(layer1Node.getNumberOfConnections()).toEqual(layer0Node.getNumberOfConnections())
             expect(layer1Node.getNumberOfNeighbors()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
             expect(layer1Node.getAllConnectionPeerDescriptors()).toEqual(layer0Node.getAllConnectionPeerDescriptors())

--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@streamr/utils'
+import { Logger, hexToBinary } from '@streamr/utils'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
@@ -51,7 +51,7 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
         layer1Node4 = await createMockConnectionLayer1Node(layer0Node4Id, layer0Node4)
 
         entryPointDescriptor = {
-            nodeId: layer0EntryPoint.getNodeId().value,
+            nodeId: hexToBinary(layer0EntryPoint.getNodeId()),
             type: NodeType.NODEJS
         }
 

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -81,7 +81,7 @@ describe('Replicate data from node to node in DHT', () => {
         // calculate offline which node is closest to the data
 
         const sortedList = new SortedContactList<Contact>({ 
-            referenceId: dataKey, 
+            referenceId: dataKey.toNodeId(),
             maxSize: 10000, 
             allowToContainReferenceId: true, 
             emitEvents: false 

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -1,15 +1,21 @@
 import { DhtNode, Events as DhtNodeEvents } from '../../src/dht/DhtNode'
 import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
-import { Logger, runAndWaitForEvents3, waitForCondition } from '@streamr/utils'
+import { Logger, hexToBinary, runAndWaitForEvents3, waitForCondition } from '@streamr/utils'
 import { createMockConnectionDhtNode, createWrappedClosestPeersRequest } from '../utils/utils'
-import { PeerID } from '../../src/helpers/PeerID'
+import { PeerID, PeerIDKey } from '../../src/helpers/PeerID'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { v4 } from 'uuid'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { RoutingMode } from '../../src/dht/routing/RoutingSession'
+import { areEqualNodeIds } from '../../src/helpers/nodeId'
 
 const logger = new Logger(module)
+
+// TODO refactor the test to not to use PeerID
+const getPeerId = (node: DhtNode) => {
+    return PeerID.fromValue(hexToBinary(node.getNodeId()))
+}
 
 describe('Route Message With Mock Connections', () => {
     let entryPoint: DhtNode
@@ -32,7 +38,7 @@ describe('Route Message With Mock Connections', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
 
         entryPointDescriptor = {
-            nodeId: entryPoint.getNodeId().value,
+            nodeId: hexToBinary(entryPoint.getNodeId()),
             type: NodeType.NODEJS
         }
 
@@ -134,19 +140,19 @@ describe('Route Message With Mock Connections', () => {
             receiveMatrix.push(arr)
         }
 
-        const numsOfReceivedMessages: Record<string, number> = {}
+        const numsOfReceivedMessages: Record<PeerIDKey, number> = {}
         routerNodes.forEach((node) => {
-            numsOfReceivedMessages[node.getNodeId().toKey()] = 0
+            numsOfReceivedMessages[getPeerId(node).toKey()] = 0
             node.on('message', (msg: Message) => {
-                numsOfReceivedMessages[node.getNodeId().toKey()] = numsOfReceivedMessages[node.getNodeId().toKey()] + 1
+                numsOfReceivedMessages[getPeerId(node).toKey()] = numsOfReceivedMessages[getPeerId(node).toKey()] + 1
                 try {
-                    const target = receiveMatrix[parseInt(node.getNodeId().toString()) - 1]
+                    const target = receiveMatrix[parseInt(getPeerId(node).toString()) - 1]
                     target[parseInt(PeerID.fromValue(msg.sourceDescriptor!.nodeId).toString()) - 1]++
                 } catch (e) {
                     console.error(e)
                 }
-                if (parseInt(node.getNodeId().toString()) > routerNodes.length || parseInt(node.getNodeId().toString()) === 0) {
-                    console.error(node.getNodeId().toString())
+                if (parseInt(getPeerId(node).toString()) > routerNodes.length || parseInt(getPeerId(node).toString()) === 0) {
+                    console.error(getPeerId(node).toString())
                 }
             })
         }
@@ -154,7 +160,7 @@ describe('Route Message With Mock Connections', () => {
         await Promise.all(
             routerNodes.map(async (node) =>
                 Promise.all(routerNodes.map(async (receiver) => {
-                    if (!node.getNodeId().equals(receiver.getNodeId())) {
+                    if (!areEqualNodeIds(node.getNodeId(), receiver.getNodeId())) {
                         const rpcWrapper = createWrappedClosestPeersRequest(sourceNode.getLocalPeerDescriptor())
                         const message: Message = {
                             serviceId: 'nonexisting_service',
@@ -183,7 +189,7 @@ describe('Route Message With Mock Connections', () => {
             , 30000)
         await Promise.all(
             Object.keys(numsOfReceivedMessages).map(async (key) =>
-                waitForCondition(() => numsOfReceivedMessages[key] >= routerNodes.length - 1, 30000)
+                waitForCondition(() => numsOfReceivedMessages[key as PeerIDKey] >= routerNodes.length - 1, 30000)
             )
         )
 

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -3,7 +3,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { Logger } from '@streamr/utils'
+import { Logger, hexToBinary } from '@streamr/utils'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
 
 const logger = new Logger(module)
@@ -25,7 +25,7 @@ describe('Scaling down a Dht network', () => {
         nodes.push(entryPoint)
 
         entrypointDescriptor = {
-            nodeId: entryPoint.getNodeId().value,
+            nodeId: hexToBinary(entryPoint.getNodeId()),
             type: NodeType.NODEJS,
             region: getRandomRegion()
         }

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -14,7 +14,6 @@ describe('Storing data in DHT', () => {
     const NUM_NODES = 100
     const MAX_CONNECTIONS = 20
     const K = 4
-    const nodeIndicesById: Record<string, number> = {}
 
     const getRandomNode = () => {
         return nodes[Math.floor(Math.random() * nodes.length)]
@@ -26,14 +25,12 @@ describe('Storing data in DHT', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
             undefined, K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
-        nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
             const node = await createMockConnectionDhtNode(nodeId, simulator, 
                 undefined, K, MAX_CONNECTIONS, 60000)
-            nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -14,7 +14,6 @@ describe('Storing data in DHT', () => {
     const NUM_NODES = 5
     const MAX_CONNECTIONS = 5
     const K = 4
-    const nodeIndicesById: Record<string, number> = {}
 
     const getRandomNode = () => {
         return nodes[Math.floor(Math.random() * nodes.length)]
@@ -26,14 +25,12 @@ describe('Storing data in DHT', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
             undefined, K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
-        nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
             const node = await createMockConnectionDhtNode(nodeId, simulator, 
                 undefined, K, MAX_CONNECTIONS, 60000)
-            nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -2,7 +2,7 @@ import { wait, randomString } from '@streamr/utils'
 import crypto from 'crypto'
 import { LocalDataStore } from '../../src/dht/store/LocalDataStore'
 import {
-    keyFromPeerDescriptor,
+    getNodeIdFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { Any } from '../../src/proto/google/protobuf/any'
@@ -72,8 +72,8 @@ describe('LocalDataStore', () => {
         localDataStore.storeEntry(storedEntry2)
         const fetchedEntries = localDataStore.getEntries(key)
         expect(fetchedEntries.size).toBe(2)
-        expectEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator1))!, storedEntry1)
-        expectEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator2))!, storedEntry2)
+        expectEqualData(fetchedEntries.get(getNodeIdFromPeerDescriptor(creator1))!, storedEntry1)
+        expectEqualData(fetchedEntries.get(getNodeIdFromPeerDescriptor(creator2))!, storedEntry2)
     })
 
     it('can remove data entries', () => {
@@ -84,7 +84,7 @@ describe('LocalDataStore', () => {
         const storedEntry2 = createMockEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
         localDataStore.storeEntry(storedEntry2)
-        localDataStore.deleteEntry(key, peerIdFromPeerDescriptor(creator1))
+        localDataStore.deleteEntry(key, getNodeIdFromPeerDescriptor(creator1))
         const fetchedEntries = getEntryArray(key)
         expect(fetchedEntries).toHaveLength(1)
         expectEqualData(fetchedEntries[0], storedEntry2)
@@ -98,8 +98,8 @@ describe('LocalDataStore', () => {
         const storedEntry2 = createMockEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
         localDataStore.storeEntry(storedEntry2)
-        localDataStore.deleteEntry(key, peerIdFromPeerDescriptor(creator1))
-        localDataStore.deleteEntry(key, peerIdFromPeerDescriptor(creator2))
+        localDataStore.deleteEntry(key, getNodeIdFromPeerDescriptor(creator1))
+        localDataStore.deleteEntry(key, getNodeIdFromPeerDescriptor(creator2))
         expect(getEntryArray(key)).toHaveLength(0)
     })
 
@@ -118,23 +118,23 @@ describe('LocalDataStore', () => {
             const storedEntry = createMockEntry({ creator: creator1 })
             localDataStore.storeEntry(storedEntry)
             const notDeletedData = localDataStore.getEntries(storedEntry.key)
-            expect(notDeletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeFalse()
-            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(creator1))
+            expect(notDeletedData.get(getNodeIdFromPeerDescriptor(creator1))!.deleted).toBeFalse()
+            const returnValue = localDataStore.markAsDeleted(storedEntry.key, getNodeIdFromPeerDescriptor(creator1))
             expect(returnValue).toBe(true)
             const deletedData = localDataStore.getEntries(storedEntry.key)
-            expect(deletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeTrue()
+            expect(deletedData.get(getNodeIdFromPeerDescriptor(creator1))!.deleted).toBeTrue()
         })
 
         it('data not stored', () => {
             const dataKey = peerIdFromPeerDescriptor(createMockPeerDescriptor())
-            const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(createMockPeerDescriptor()))
+            const returnValue = localDataStore.markAsDeleted(dataKey.value, getNodeIdFromPeerDescriptor(createMockPeerDescriptor()))
             expect(returnValue).toBe(false)
         })
 
         it('data not stored by the given creator', () => {
             const storedEntry = createMockEntry({})
             localDataStore.storeEntry(storedEntry)
-            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(createMockPeerDescriptor()))
+            const returnValue = localDataStore.markAsDeleted(storedEntry.key, getNodeIdFromPeerDescriptor(createMockPeerDescriptor()))
             expect(returnValue).toBe(false)
         })
     })

--- a/packages/dht/test/unit/RandomContactList.test.ts
+++ b/packages/dht/test/unit/RandomContactList.test.ts
@@ -1,8 +1,12 @@
 import { RandomContactList } from '../../src/dht/contact/RandomContactList'
 import { PeerID } from '../../src/helpers/PeerID'
+import { NodeID, getNodeIdFromBinary } from '../../src/helpers/nodeId'
 
-const createItem = (nodeId: Uint8Array): { getPeerId: () => PeerID } => {
-    return { getPeerId: () => PeerID.fromValue(nodeId) }
+const createItem = (nodeId: Uint8Array): { getNodeId: () => NodeID, getPeerId: () => PeerID } => {
+    return { 
+        getNodeId: () => getNodeIdFromBinary(nodeId),
+        getPeerId: () => PeerID.fromValue(nodeId)
+    }
 }
 
 describe('RandomContactList', () => {
@@ -13,7 +17,7 @@ describe('RandomContactList', () => {
     const item4 = createItem(new Uint8Array([0, 0, 0, 4]))
 
     it('adds contacts correctly', () => {
-        const list = new RandomContactList(item0.getPeerId(), 5, 1)
+        const list = new RandomContactList(item0.getNodeId(), 5, 1)
         list.addContact(item1)
         list.addContact(item2)
         list.addContact(item3)
@@ -27,15 +31,15 @@ describe('RandomContactList', () => {
     })
 
     it('removes contacts correctly', () => {
-        const list = new RandomContactList(item0.getPeerId(), 5, 1)
+        const list = new RandomContactList(item0.getNodeId(), 5, 1)
         list.addContact(item1)
         list.addContact(item2)
         list.addContact(item3)
         list.addContact(item4)
-        list.removeContact(item2.getPeerId())
-        expect(list.getContact(item1.getPeerId())).toBeTruthy()
-        expect(list.getContact(item3.getPeerId())).toBeTruthy()
-        expect(list.getContact(item4.getPeerId())).toBeTruthy()
+        list.removeContact(item2.getNodeId())
+        expect(list.getContact(item1.getNodeId())).toBeTruthy()
+        expect(list.getContact(item3.getNodeId())).toBeTruthy()
+        expect(list.getContact(item4.getNodeId())).toBeTruthy()
         expect(list.getContacts()).toEqual(
             [item1, item3, item4]
         )

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { Router } from '../../src/dht/routing/Router'
-import { PeerID, PeerIDKey } from '../../src/helpers/PeerID'
+import { PeerID } from '../../src/helpers/PeerID'
 import { 
     Message,
     MessageType,
@@ -13,6 +13,7 @@ import {
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createWrappedClosestPeersRequest } from '../utils/utils'
 import { FakeRpcCommunicator } from '../utils/FakeRpcCommunicator'
+import { NodeID } from '../../src/helpers/nodeId'
 
 describe('Router', () => {
     let router: Router
@@ -46,7 +47,7 @@ describe('Router', () => {
         destinationPeer: peerDescriptor1,
         sourcePeer: peerDescriptor2
     }
-    let connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    let connections: Map<NodeID, DhtNodeRpcRemote>
     const rpcCommunicator = new FakeRpcCommunicator()
 
     const createMockDhtNodeRpcRemote = (destination: PeerDescriptor): DhtNodeRpcRemote => {
@@ -80,7 +81,7 @@ describe('Router', () => {
     })
 
     it('doRouteMessage with connections', async () => {
-        connections.set(PeerID.fromString('test').toKey(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(PeerID.fromString('test').toNodeId(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', {
             message,
             destinationPeer: peerDescriptor2,
@@ -98,7 +99,7 @@ describe('Router', () => {
     })
 
     it('route server with connections', async () => {
-        connections.set(PeerID.fromString('test').toKey(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(PeerID.fromString('test').toNodeId(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', routedMessage) as RouteMessageAck
         expect(ack.error).toBeUndefined()
     })
@@ -115,7 +116,7 @@ describe('Router', () => {
     })
 
     it('forward server with connections', async () => {
-        connections.set(PeerID.fromString('test').toKey(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(PeerID.fromString('test').toNodeId(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('forwardMessage', routedMessage) as RouteMessageAck
         expect(ack.error).toBeUndefined()
     })

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -3,15 +3,15 @@ import { RoutingSession } from '../../src/dht/routing/RoutingSession'
 import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createWrappedClosestPeersRequest } from '../utils/utils'
 import { hexToBinary } from '@streamr/utils'
-import { PeerIDKey } from '../../src/helpers/PeerID'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
-import { keyFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { NodeID } from '../../src/helpers/nodeId'
 
 describe('RoutingSession', () => {
 
     let session: RoutingSession
-    let connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    let connections: Map<NodeID, DhtNodeRpcRemote>
     let rpcCommunicator: RoutingRpcCommunicator
 
     const mockPeerDescriptor1: PeerDescriptor = {
@@ -61,15 +61,15 @@ describe('RoutingSession', () => {
     })
 
     it('findMoreContacts', () => {
-        connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        connections.set(getNodeIdFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
         const contacts = session.updateAndGetRoutablePeers()
         expect(contacts.length).toBe(1)
     })
 
     it('findMoreContacts peer disconnects', () => {
-        connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        connections.set(getNodeIdFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
         expect(session.updateAndGetRoutablePeers().length).toBe(1)
-        connections.delete(keyFromPeerDescriptor(mockPeerDescriptor2))
+        connections.delete(getNodeIdFromPeerDescriptor(mockPeerDescriptor2))
         expect(session.updateAndGetRoutablePeers().length).toBe(0)
     })
 

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -1,8 +1,12 @@
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { PeerID } from '../../src/helpers/PeerID'
+import { NodeID, getNodeIdFromBinary } from '../../src/helpers/nodeId'
 
-const createItem = (nodeId: Uint8Array): { getPeerId: () => PeerID } => {
-    return { getPeerId: () => PeerID.fromValue(nodeId) }
+const createItem = (nodeId: Uint8Array): { getNodeId: () => NodeID, getPeerId: () => PeerID } => {
+    return { 
+        getNodeId: () => getNodeIdFromBinary(nodeId),
+        getPeerId: () => PeerID.fromValue(nodeId)
+    }
 }
 
 describe('SortedContactList', () => {
@@ -13,19 +17,19 @@ describe('SortedContactList', () => {
     const item4 = createItem(new Uint8Array([0, 0, 0, 4]))
 
     it('compares Ids correctly', async () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 10, allowToContainReferenceId: true, emitEvents: false })
-        expect(list.compareIds(item0.getPeerId(), item0.getPeerId())).toBe(0)
-        expect(list.compareIds(item1.getPeerId(), item1.getPeerId())).toBe(0)
-        expect(list.compareIds(item0.getPeerId(), item1.getPeerId())).toBe(-1)
-        expect(list.compareIds(item0.getPeerId(), item2.getPeerId())).toBe(-2)
-        expect(list.compareIds(item1.getPeerId(), item0.getPeerId())).toBe(1)
-        expect(list.compareIds(item2.getPeerId(), item0.getPeerId())).toBe(2)
-        expect(list.compareIds(item2.getPeerId(), item3.getPeerId())).toBe(-1)
-        expect(list.compareIds(item1.getPeerId(), item4.getPeerId())).toBe(-3)
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 10, allowToContainReferenceId: true, emitEvents: false })
+        expect(list.compareIds(item0.getNodeId(), item0.getNodeId())).toBe(0)
+        expect(list.compareIds(item1.getNodeId(), item1.getNodeId())).toBe(0)
+        expect(list.compareIds(item0.getNodeId(), item1.getNodeId())).toBe(-1)
+        expect(list.compareIds(item0.getNodeId(), item2.getNodeId())).toBe(-2)
+        expect(list.compareIds(item1.getNodeId(), item0.getNodeId())).toBe(1)
+        expect(list.compareIds(item2.getNodeId(), item0.getNodeId())).toBe(2)
+        expect(list.compareIds(item2.getNodeId(), item3.getNodeId())).toBe(-1)
+        expect(list.compareIds(item1.getNodeId(), item4.getNodeId())).toBe(-3)
     })
 
     it('orders itself correctly', async () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 10, allowToContainReferenceId: true, emitEvents: false })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 10, allowToContainReferenceId: true, emitEvents: false })
         list.addContact(item3)
         list.addContact(item2)
         list.addContact(item1)
@@ -37,11 +41,11 @@ describe('SortedContactList', () => {
     })
 
     it('handles contacted nodes correctly', async () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 10, allowToContainReferenceId: false, emitEvents: false })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 10, allowToContainReferenceId: false, emitEvents: false })
         list.addContact(item3)
         list.addContact(item2)
         list.addContact(item1)
-        list.setContacted(item2.getPeerId())
+        list.setContacted(item2.getNodeId())
         const contacts = list.getUncontactedContacts(3)
         expect(contacts.length).toEqual(2)
         expect(contacts[0]).toEqual(item1)
@@ -49,7 +53,7 @@ describe('SortedContactList', () => {
     })
 
     it('cannot exceed maxSize', async () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 3, allowToContainReferenceId: false, emitEvents: true })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 3, allowToContainReferenceId: false, emitEvents: true })
         const onContactRemoved = jest.fn()
         list.on('contactRemoved', onContactRemoved)
         list.addContact(item1)
@@ -58,30 +62,30 @@ describe('SortedContactList', () => {
         list.addContact(item2)
         expect(list.getSize()).toEqual(3)
         expect(onContactRemoved).toBeCalledWith(item4, [item1, item2, item3])
-        expect(list.getContact(item4.getPeerId())).toBeFalsy()
+        expect(list.getContact(item4.getNodeId())).toBeFalsy()
     })
 
     it('removing contacts', async () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: true })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: true })
         const onContactRemoved = jest.fn()
         list.on('contactRemoved', onContactRemoved)
         list.addContact(item4)
         list.addContact(item3)
         list.addContact(item2)
         list.addContact(item1)
-        list.removeContact(item2.getPeerId())
+        list.removeContact(item2.getNodeId())
         expect(list.getSize()).toEqual(3)
-        expect(list.getContact(item2.getPeerId())).toBeFalsy()
+        expect(list.getContact(item2.getNodeId())).toBeFalsy()
         expect(list.getContactIds()).toEqual(list.getContactIds().sort(list.compareIds))
         expect(list.getAllContacts()).toEqual([item1, item3, item4])
         expect(onContactRemoved).toBeCalledWith(item2, [item1, item3, item4])
-        const ret = list.removeContact(PeerID.fromValue(Buffer.from([0, 0, 0, 6])))
+        const ret = list.removeContact(getNodeIdFromBinary(Buffer.from([0, 0, 0, 6])))
         expect(ret).toEqual(false)
     })
 
     it('get closest contacts', () => {
         const list = new SortedContactList({
-            referenceId: item0.getPeerId(), 
+            referenceId: item0.getNodeId(), 
             maxSize: 8, 
             allowToContainReferenceId: false, 
             emitEvents: false 
@@ -95,14 +99,14 @@ describe('SortedContactList', () => {
     })
 
     it('get active contacts', () => {
-        const list = new SortedContactList({ referenceId: item0.getPeerId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: false })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: false })
         list.addContact(item1)
         list.addContact(item3)
         list.addContact(item4)
         list.addContact(item2)
-        list.setActive(item2.getPeerId())
-        list.setActive(item3.getPeerId())
-        list.setActive(item4.getPeerId())
+        list.setActive(item2.getNodeId())
+        list.setActive(item3.getNodeId())
+        list.setActive(item4.getNodeId())
         expect(list.getActiveContacts()).toEqual([item2, item3, item4])
     })
 })


### PR DESCRIPTION
In this PR we implement most of future improvements listed in https://github.com/streamr-dev/network/pull/2155. The node IDs are internally stored as strings instead of `PeerID` objects. This should optimize CPU usage as we do significantly less `PeerID.fromValue({})` calls and other unnecessary data conversion operations.

For data keys we still use `PeerIDKey`. We'll refactor that in a separate PR (maybe we should introduce a new `DataKey` branded string for it).

Also refactored `excludedNodeIDs` to be set `Set` instead of array. This should optimize the `SortedContactList#addContact` operation.


## Future improvements

- Use `sortedIndexBy` in `SortedContactList#removeContact`.
- See added TODO comments. E.g. we could remove areEqualNodeIds and just use === comparison. This is a good approach if compiler/`eslint` would warn if we'd incorrectly compare `NodeID` to `UInt8Array` with ===.
- Many classes could maybe pass `NodeID`s instead of `PeerDescriptor`s, if the receiver class is not interested about the contact information. Maybe e.g. `PeerDescriptor` could store `PeerDescriptor`s internally, but methods could get `NodeID`s as parameters / return types.