### PR TITLE
chore: Add utility mapped type for Java-like enforcement of method parameter…

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -27,7 +27,7 @@ import {
     MetricsContext,
     hexToBinary,
     merge,
-    strictly,
+    sI,
     waitForCondition
 } from '@streamr/utils'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
@@ -134,7 +134,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     return ret
 }
 
-export class DhtNode extends EventEmitter<Events> implements strictly<DhtNode, ITransport> {
+export class DhtNode extends EventEmitter<Events> implements sI<DhtNode, ITransport> {
 
     private readonly config: StrictDhtNodeOptions
     private rpcCommunicator?: RoutingRpcCommunicator

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -19,7 +19,7 @@ import {
     ExternalStoreDataResponse,
     RecursiveOperation,
 } from '../proto/packages/dht/protos/DhtRpc'
-import { ITransport, TransportEvents } from '../transport/ITransport'
+import { ITransport, SendOptions, TransportEvents } from '../transport/ITransport'
 import { ConnectionManager, PortRange, TlsCertificate } from '../connection/ConnectionManager'
 import { DhtNodeRpcClient, ExternalApiRpcClient, StoreRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
 import {
@@ -27,6 +27,7 @@ import {
     MetricsContext,
     hexToBinary,
     merge,
+    strictly,
     waitForCondition
 } from '@streamr/utils'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
@@ -133,7 +134,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     return ret
 }
 
-export class DhtNode extends EventEmitter<Events> implements ITransport {
+export class DhtNode extends EventEmitter<Events> implements strictly<DhtNode, ITransport> {
 
     private readonly config: StrictDhtNodeOptions
     private rpcCommunicator?: RoutingRpcCommunicator
@@ -428,7 +429,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.peerManager!.handlePeerLeaving(contact)
     }
 
-    public async send(msg: Message): Promise<void> {
+    public async send(msg: Message, _opts?: SendOptions): Promise<void> {
         if (!this.started || this.abortController.signal.aborted) {
             return
         }

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -41,6 +41,7 @@ import { executeSafePromise } from './executeSafePromise'
 import { binaryToHex, binaryToUtf8, hexToBinary, utf8ToBinary, areEqualBinaries } from './binaryUtils'
 import { filePathToNodeFormat } from './filePathToNodeFormat'
 import { retry } from './retry'
+import { strictly } from './strictly'
 
 export {
     BrandedString,
@@ -94,7 +95,8 @@ export {
     utf8ToBinary,
     areEqualBinaries,
     filePathToNodeFormat,
-    retry
+    retry,
+    strictly
 }
 
 export {

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -41,7 +41,7 @@ import { executeSafePromise } from './executeSafePromise'
 import { binaryToHex, binaryToUtf8, hexToBinary, utf8ToBinary, areEqualBinaries } from './binaryUtils'
 import { filePathToNodeFormat } from './filePathToNodeFormat'
 import { retry } from './retry'
-import { strictCb, strictly } from './strictly'
+import { sF, sI } from './strictly'
 
 export {
     BrandedString,
@@ -96,8 +96,8 @@ export {
     areEqualBinaries,
     filePathToNodeFormat,
     retry,
-    strictly,
-    strictCb
+    sI,
+    sF
 }
 
 export {

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -41,7 +41,7 @@ import { executeSafePromise } from './executeSafePromise'
 import { binaryToHex, binaryToUtf8, hexToBinary, utf8ToBinary, areEqualBinaries } from './binaryUtils'
 import { filePathToNodeFormat } from './filePathToNodeFormat'
 import { retry } from './retry'
-import { strictly } from './strictly'
+import { strictCb, strictly } from './strictly'
 
 export {
     BrandedString,
@@ -96,7 +96,8 @@ export {
     areEqualBinaries,
     filePathToNodeFormat,
     retry,
-    strictly
+    strictly,
+    strictCb
 }
 
 export {

--- a/packages/utils/src/strictly.ts
+++ b/packages/utils/src/strictly.ts
@@ -40,3 +40,40 @@ export type strictly<C, I> = {
         // else if not a function in I, pass it through 
         : I[k]
 }
+
+/**  
+* Ensures that the callback passed as an argument has exactly the same
+* parameter types as in the type definition. This utility type is
+* to be used in the definitions of functions that take callbacks as arguments.
+* No action from the callers of the function is required.
+* @param C - placeholder parameter for the type of the callback function passed as an argument
+* to the function call. NOTE: the function needs to be converted to a generic in order to use strictCb. 
+* The compiler will automatically infer parameter C from the context when the function is called, and 
+* the caller of the function does not need to know that the function is generic. 
+* @param I - F the usual type definition of the callback function. 
+* @returns - strict callback function type that causes a compiler error if the parameters
+* of the callback passed as an argument do not match exactly the parameters of the callback type definition
+* @example ```ts  fetchValue<C>(callback: strictCb<C, (result: string) => void>): void {
+        callback('some value')
+    } ```
+*/
+
+export type strictCb<C, F extends (...args: any) => any> = 
+    C extends (...args: infer B) => infer Q
+        ? ( F extends (...args: infer A) => infer R
+            ? ( A extends B
+                ? ( B extends A
+                    ? ( Q extends R
+                        ? ( R extends Q
+                            ? C
+                            : F & 'The return values of the callbacks differ'
+                        )
+                        : F & 'The return values of the callbacks differ'
+                    )
+                    : F & 'The types of the parameters of the callbacks differ'
+                )
+                : F & 'The types of the parameters of the callbacks differ' 
+            ) 
+            : F & 'The callback is not a function'
+        )
+        : F & 'The callback is not a function'

--- a/packages/utils/src/strictly.ts
+++ b/packages/utils/src/strictly.ts
@@ -1,4 +1,5 @@
 /**  
+* sI, the strictInterface utility type  
 * Checks that the implementation of an interface has
 * the public methods defined in the interface with the exactly same
 * parameter types as the interface.
@@ -8,23 +9,41 @@
 * @returns - an interface that is otherwise the same as I, but the methods
 *  whose parameters do not match between C and I are marked with a type that
 *  causes a compiler error when used in combination with the 'implements' keyword.
-* @example ```ts class MyClass implements strictly<MyClass, MyInterface> { ... } ```
+* @example ```
+
+// usage with a an interface
+
+class MyClass implements sI<MyClass, MyInterface> { ... } 
+
+// usage with an abstract class
+
+abstract class MyAbstractClass { ... }
+class MyClass extends MyAbstractClass implements sI<MyClass, MyAbstractClass> { ... }
+
+```
 */
 
-export type strictly<C, I> = {
+export type sI<C, I> = {
     [k in keyof I]:
         // check if it is a function in I
-        I[k] extends (...args: infer A) => infer _R
+        I[k] extends (...args: infer A) => infer R
             // if it is a function, check if the exists in C
             ? ( k extends keyof C
                 // if the key exists in C, check if it is a function in C
-                ? ( C[k] extends (...args: infer B) => infer _Q 
+                ? ( C[k] extends (...args: infer B) => infer Q 
                     // if it is a function in C, check if the parameters match one way
                    ? (A extends B
                         //if parameters match one way, check if they match the other way
                         ? (B extends A  
-                            // if parameters match also the other way, pass it through
-                            ? I[k] 
+                            // if parameters match also the other way, check the return types
+                            ? ( R extends Q
+                                ? ( Q extends R
+                                    // return values match both ways, pass it through  
+                                    ? I[k] 
+                                    : I[k] & 'The return values of the functions differ between the implementation and the interface'
+                                )
+                                : I[k] & 'The return values of the functions differ between the implementation and the interface'
+                            )
                             //else if parameters do not match the other way, pass it through with a type that causes compiler error
                             : I[k] & 'The function parameters differ between the implementation and the interface'
                         )  
@@ -42,23 +61,27 @@ export type strictly<C, I> = {
 }
 
 /**  
-* Ensures that the callback passed as an argument has exactly the same
-* parameter types as in the type definition. This utility type is
-* to be used in the definitions of functions that take callbacks as arguments.
-* No action from the callers of the function is required.
-* @param C - placeholder parameter for the type of the callback function passed as an argument
-* to the function call. NOTE: the function needs to be converted to a generic in order to use strictCb. 
-* The compiler will automatically infer parameter C from the context when the function is called, and 
-* the caller of the function does not need to know that the function is generic. 
-* @param I - F the usual type definition of the callback function. 
-* @returns - strict callback function type that causes a compiler error if the parameters
-* of the callback passed as an argument do not match exactly the parameters of the callback type definition
-* @example ```ts  fetchValue<C>(callback: strictCb<C, (result: string) => void>): void {
+* sF, the strictFunction utility type.
+* Ensures that the function passed as an argument has exactly the same
+* parameter types and return type as in the type definition. This utility type is
+* especially useful in the defining of functions that take callbacks as arguments.
+* @param C - function to be checked.
+* @param I - function type definition to check the function against. 
+* @returns - strict function type that causes a compiler error if the parameter or return types
+* do not match exactly the parameters of the function type definition
+* @example ```
+// Usage in a callback function definition
+// NOTE: the function needs to be converted to a generic in order to use strictCb. 
+// The compiler will automatically infer parameter C from the context when the function is called, and 
+// the caller of the function does not need to know that the function is generic.  
+
+fetchValue<C>(callback: sF<C, (result: string) => void>): void {
         callback('some value')
-    } ```
+} 
+```
 */
 
-export type strictCb<C, F extends (...args: any) => any> = 
+export type sF<C, F extends (...args: any) => any> = 
     C extends (...args: infer B) => infer Q
         ? ( F extends (...args: infer A) => infer R
             ? ( A extends B
@@ -66,14 +89,14 @@ export type strictCb<C, F extends (...args: any) => any> =
                     ? ( Q extends R
                         ? ( R extends Q
                             ? C
-                            : F & 'The return values of the callbacks differ'
+                            : F & 'The return values of the functions differ'
                         )
-                        : F & 'The return values of the callbacks differ'
+                        : F & 'The return values of the functions differ'
                     )
-                    : F & 'The types of the parameters of the callbacks differ'
+                    : F & 'The types of the parameters of the functions differ'
                 )
-                : F & 'The types of the parameters of the callbacks differ' 
+                : F & 'The types of the parameters of the functions differ' 
             ) 
-            : F & 'The callback is not a function'
+            : F & 'The parameter is not a function'
         )
-        : F & 'The callback is not a function'
+        : F & 'The parameter is not a function'

--- a/packages/utils/src/strictly.ts
+++ b/packages/utils/src/strictly.ts
@@ -1,0 +1,42 @@
+/**  
+* Checks that the implementation of an interface has
+* the public methods defined in the interface with the exactly same
+* parameter types as the interface.
+
+* @param C - the class that implements the interface
+* @param I - the interface
+* @returns - an interface that is otherwise the same as I, but the methods
+*  whose parameters do not match between C and I are marked with a type that
+*  causes a compiler error when used in combination with the 'implements' keyword.
+* @example ```ts class MyClass implements strictly<MyClass, MyInterface> { ... } ```
+*/
+
+export type strictly<C, I> = {
+    [k in keyof I]:
+        // check if it is a function in I
+        I[k] extends (...args: infer A) => infer _R
+            // if it is a function, check if the exists in C
+            ? ( k extends keyof C
+                // if the key exists in C, check if it is a function in C
+                ? ( C[k] extends (...args: infer B) => infer _Q 
+                    // if it is a function in C, check if the parameters match one way
+                   ? (A extends B
+                        //if parameters match one way, check if they match the other way
+                        ? (B extends A  
+                            // if parameters match also the other way, pass it through
+                            ? I[k] 
+                            //else if parameters do not match the other way, pass it through with a type that causes compiler error
+                            : I[k] & 'The function parameters differ between the implementation and the interface'
+                        )  
+                    // else if parameters do not match one way, pass it through with a type that causes compiler error
+                    : I[k] & 'The function parameters differ between the implementation and the interface'
+                    ) 
+                // else if not a function in C, pass it through
+                : I[k]
+                ) 
+            // else if not exists in C, pass it through
+            : I[k]
+            )
+        // else if not a function in I, pass it through 
+        : I[k]
+}


### PR DESCRIPTION
Add Java-like type checking of method parameter types when implementing an interface, and when defining a callback.

Usage of strict interface implementation: class MyClass implements strictly<MyClass, MyInterface> { ... }

Results: shows readable compiler errors in IDE and compiler if the method signatures do not match exactly.

/**

Checks that the implementation of an interface has

the public methods defined in the interface with the exactly same

parameter types as the interface.

@param C - the class that implements the interface

@param I - the interface

@returns - an interface that is otherwise the same as I, but the methods

whose parameters do not match between C and I are marked with a type that

causes a compiler error when used in combination with the 'implements' keyword.

@example ts class MyClass implements strictly<MyClass, MyInterface> { ... } 
*/

Usage of strictly typed callbacks:

/**  
* Ensures that the callback passed as an argument has exactly the same
* parameter types as in the type definition. This utility type is
* to be used in the definitions of functions that take callbacks as arguments.
* No action from the callers of the function is required.
* @param C - placeholder parameter for the type of the callback function passed as an argument
* to the function call. NOTE: the function needs to be converted to a generic in order to use strictCb. 
* The compiler will automatically infer parameter C from the context when the function is called, and 
* the caller of the function does not need to know that the function is generic. 
* @param I - F the usual type definition of the callback function. 
* @returns - strict callback function type that causes a compiler error if the parameters
* of the callback passed as an argument do not match exactly the parameters of the callback type definition
* @example ```ts  fetchValue<C>(callback: strictCb<C, (result: string) => void>): void {
        callback('some value')
    } ```
*/
