### PR TITLE
feat(DHT): use a separate contacted set for additional distant joins

### DIFF
--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -47,7 +47,7 @@ export class PeerDiscovery {
     ): Promise<void> {
         const contactedPeers = new Set<DhtAddress>()
         const distantJoinConfig = doAdditionalDistantPeerDiscovery 
-            ? { enabled: true, contactedPeers: new Set<DhtAddress>() } : { enabled: false } as { enabled: false }
+            ? { enabled: true, contactedPeers: new Set<DhtAddress>() } : { enabled: false } as const
         await Promise.all(entryPoints.map((entryPoint) => this.joinThroughEntryPoint(
             entryPoint,
             contactedPeers,


### PR DESCRIPTION
## Summary

In many cases distant joins were not even properly started due to the contacted set being shared with the contacted sets used for regular joining. By ensuring that the sets are unique both operations are fully completed.