### PR TITLE
hotfix(broker): operator list pagination

### DIFF
--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -329,11 +329,11 @@ export class ContractFacade {
 
     private async getOperatorAddresses(requiredBlockNumber: number): Promise<EthereumAddress[]> {
         // TODO: use pagination or find a clever efficient way of selecting a random operator (NET-1113)
-        const createQuery = () => {
+        const createQuery = (lastId: string, pageSize: number) => {
             return {
                 query: `
                     {
-                        operators(first: 1000) {
+                        operators(where: {id_gt: "${lastId}"}, first: ${pageSize}) {
                             id
                         }
                     }

--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -333,7 +333,7 @@ export class ContractFacade {
             return {
                 query: `
                     {
-                        operators(where: {id_gt: "${lastId}"}, first: ${pageSize}) {
+                        operators(where: {totalStakeInSponsorshipsWei_gt: "0", id_gt: "${lastId}"}, first: ${pageSize}) {
                             id
                         }
                     }

--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -328,7 +328,7 @@ export class ContractFacade {
     }
 
     private async getOperatorAddresses(requiredBlockNumber: number): Promise<EthereumAddress[]> {
-        // TODO: use pagination or find a clever efficient way of selecting a random operator (NET-1113)
+        // TODO: find a clever more efficient way of selecting a random operator? (NET-1113)
         const createQuery = (lastId: string, pageSize: number) => {
             return {
                 query: `


### PR DESCRIPTION
## Summary

Fix issue where we fetched "1st page" forever. Implement actual pagination logic (this also fixes the aforementioned bug) Additionally filter operators whose total staked wei is greater than zero.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
