### PR TITLE
ETH-744: new iteration on voting gas (bump to 1.3M)

### DIFF
--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -469,7 +469,7 @@ export class ContractFacade {
             sponsorship,
             targetOperator,
             voteData,
-            { ...this.getEthersOverrides(), gasLimit: '1000000' }
+            { ...this.getEthersOverrides(), gasLimit: '1300000' }
         )).wait()
     }
 


### PR DESCRIPTION
## Summary
this time we have a calculation based on [an (out of gas) transaction](https://dashboard.tenderly.co/tx/polygon/0xb6e86f9ce62820719f5056283d6022be60baa900bf730d1efacf77957823b3c9/debugger?trace=0.0.3.0.4.13.2.21.2)
* one DATA reward send can cost up to 85k gas
    * times 7 reviewers + flagger
    * that's 8 * 85k = 680k
* vote+resolution then kicking (removing the operator) cost 563k
    * let's round that up to 600k
* Total: 1280k ~= 1.3M

## Changes

* gas 1M -> 1.3M

## Limitations and future improvements

Iterate again if this is not enough, I guess

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.