### PR TITLE
feat(cli-tools): Internal `token-mint` command can mint for the authenticated user

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-token-mint.ts
+++ b/packages/cli-tools/bin/streamr-internal-token-mint.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 
-import { _operatorContractUtils } from '@streamr/sdk'
+import StreamrClient, { _operatorContractUtils } from '@streamr/sdk'
 import { parseEther } from 'ethers'
-import { createCommand } from '../src/command'
+import { createClientCommand } from '../src/command'
 
-createCommand().action(async (targetAddress: string, dataTokenAmount: string, gasAmount?: string) => {
+const SELF_TARGET_ADDRESS_ID = 'self'
+
+createClientCommand(async (client: StreamrClient, targetAddress: string, dataTokenAmount: string, gasAmount?: string) => {
+    if (targetAddress === SELF_TARGET_ADDRESS_ID) {
+        targetAddress = await client.getUserId()
+    }
     const adminWallet = _operatorContractUtils.getTestAdminWallet()
     const token = _operatorContractUtils.getTestTokenContract().connect(adminWallet)
     await (await token.mint(targetAddress, parseEther(dataTokenAmount))).wait()
@@ -17,5 +22,6 @@ createCommand().action(async (targetAddress: string, dataTokenAmount: string, ga
     }
 })
     .arguments('<targetAddress> <dataTokenAmount> [gasAmount]')
-    .description('mint test tokens and optionally transfer gas to the given Ethereum address')
+    .description('mint test tokens and optionally transfer gas to the given Ethereum address' +
+        '\n\nNote: use keyword "self" as targetAddress to mint for the authenticated user')
     .parseAsync()

--- a/packages/cli-tools/src/permission.ts
+++ b/packages/cli-tools/src/permission.ts
@@ -48,6 +48,7 @@ export const runModifyPermissionsCommand = (
         .addArgument(new Argument('<streamId>'))
         .addArgument(new Argument('<user>'))
         .addArgument(new Argument('<permissions...>').choices(Array.from(PERMISSIONS.keys())))
-        .description(`${modification} permission: use keyword "public" as a user to ${modification} a public permission`)
+        .description(`${modification} permission` +
+            `\n\nNote: use keyword "public" as user to ${modification} a public permission`)
         .parseAsync(process.argv)
 }


### PR DESCRIPTION
Improved internal `token-mint` command so that it easier to mint tokens and gas for the authenticated user. Now it is possible to use keyword `self` in place of `targetAddress`. When that is used, the target address is calculated from the provided private key.

## Example

```
streamr internal token-mint self 1234 5678 --private-key ...
```

## Other changes

The permission commands also use special keyword similar like the `self`-keyword introduced in this PR. Unified the cli-tools command help to use the same style in those commands as we now use in the `token-mint` command.