### PR TITLE
chore(utils): Reduce logging in `TheGraphClient#waitUntilIndexed()`

### DIFF
--- a/packages/utils/src/TheGraphClient.ts
+++ b/packages/utils/src/TheGraphClient.ts
@@ -162,7 +162,10 @@ class IndexingState {
     }
 
     async waitUntilIndexed(blockNumber: number): Promise<void> {
-        this.logger.debug('Wait until The Graph is synchronized', { blockTarget: blockNumber })
+        if (blockNumber <= this.blockNumber) {
+            return
+        }
+        this.logger.debug('Wait until The Graph is synchronized', { blockNumber: this.blockNumber, blockTarget: blockNumber })
         const gate = this.getOrCreateGate(blockNumber)
         try {
             await withTimeout(


### PR DESCRIPTION
No need to log if nothing to sync.