### PR TITLE
chore!: [NET-1471] Node v20 required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes before Tatum release are not documented in this file.
   - Refer to [the docs](https://docs.streamr.network/usage/sdk/how-to-use) for migration details
 - **BREAKING CHANGE**: The string values in `Message.signatureType` now correspond with the `KeyType` values. This means the previously output value `SECP256K1` is now `ECDSA_SECP256K1_EVM`.
 - **BREAKING CHANGE**: Rename `groupKeyId` field `encryptionKeyId` in `Message` interface (https://github.com/streamr-dev/network/pull/3084)
+- **BREAKING CHANGE**: Node.js v20 or higher is required (https://github.com/streamr-dev/network/pull/3138)
 
 #### Deprecated
 
@@ -48,6 +49,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Changed
 
+- **BREAKING CHANGE**: Node.js v20 or higher is required (https://github.com/streamr-dev/network/pull/3138)
+
 #### Deprecated
 
 #### Removed
@@ -65,6 +68,7 @@ Changes before Tatum release are not documented in this file.
 #### Changed
 
 - **BREAKING CHANGE**: CLI tool command `streamr wallet whoami` is now `streamr identity whoami` (https://github.com/streamr-dev/network/pull/3074)
+- **BREAKING CHANGE**: Node.js v20 or higher is required (https://github.com/streamr-dev/network/pull/3138)
 
 #### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Monorepo containing the main components of Streamr Network.
 * [trackerless-network](packages/trackerless-network/README.md) (@streamr/trackerless-network)
 
 ## NPM scripts
-Node.js version 20 is recommended.
+Node.js version 22 is recommended.
 
 The monorepo is managed using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces).
 

--- a/docs/docs/guides/how-to-run-streamr-node.md
+++ b/docs/docs/guides/how-to-run-streamr-node.md
@@ -143,7 +143,7 @@ See [Docker's documentation](https://docs.docker.com/engine/reference/commandlin
 
 ## The Streamr node npm guide
 ### Step 1: Install the recommended version using npm
-If you don’t have Node.js installed, install it using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) or manually from the [Node.js site](https://nodejs.org/en/download/). The Streamr node requires at least Node.js version 16.x. Once installed, you can download, configure, and start the Streamr node.
+If you don’t have Node.js installed, install it using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) or manually from the [Node.js site](https://nodejs.org/en/download/). The Streamr node requires at least Node.js version 20.x. Once installed, you can download, configure, and start the Streamr node.
 
 - Run `npm install -g @streamr/node` to download and install the package. You may need administrative access to run this command. The recommended version may be different to the version listed here, if in doubt, check the [npm registry](https://www.npmjs.com/package/@streamr/node?activeTab=versions).
 

--- a/docs/docs/guides/nodejs.md
+++ b/docs/docs/guides/nodejs.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 This is a quickstart guide on creating your first stream using the Streamr TypeScript SDK in a NodeJS script.
 
 **Prerequisites:**
--   NPM v8 or greater
--   NodeJS 18.13.x or greater (version 20 and later ideally)
+-   NPM v10 or greater
+-   NodeJS 20.x or greater (version 22 and later ideally)
 -   A small amount of `POL` to pay for gas on Polygon mainnet. You can reachout to us on the #dev channel of [Discord](https://discord.gg/gZAm8P7hK8) for some tokens.
 
 :::tip Key Point:

--- a/docs/docs/guides/use-any-language-or-device.md
+++ b/docs/docs/guides/use-any-language-or-device.md
@@ -8,8 +8,8 @@ This tutorial will show you how to publish data into the Streamr Network from in
 
 **Prerequisites:**
 
--   NPM v8 or greater
--   NodeJS 18.x or greater (Ideally v20+)
+-   NPM v10 or greater
+-   NodeJS 20.x or greater (Ideally v22+)
 -   MacOS/Linux environments (Windows environments may require minor adjustments)
 -   A small amount of `POL` to pay for gas on Polygon mainnet. You can reachout to us on the #dev channel of [Discord](https://discord.gg/gZAm8P7hK8) for some tokens.
 -   A MQTT library of your choice (this tutorial uses [MQTT.js](https://www.npmjs.com/package/mqtt))

--- a/docs/docs/guides/web-app-frameworks.md
+++ b/docs/docs/guides/web-app-frameworks.md
@@ -7,8 +7,8 @@ In this quickstart guide, you'll be using Streamr in a **ReactJS** web applicati
 
 **Prerequisites:**
 
--   NPM v8 or greater
--   NodeJS 18.x or greater (Ideally v20+)
+-   NPM v10 or greater
+-   NodeJS 20.x or greater (Ideally v22+)
 -   A basic understanding of ReactJS or NextJS
 -   A small amount of `POL` to pay for gas on Polygon mainnet. You can reachout to us on the #dev channel of [Discord](https://discord.gg/gZAm8P7hK8) for some tokens.
 

--- a/docs/docs/usage/cli-tool.md
+++ b/docs/docs/usage/cli-tool.md
@@ -12,7 +12,7 @@ The Streamr Command line (CLI) tool is for interacting with the Streamr Network.
 npm install -g @streamr/cli-tools
 ```
 
-Node.js `16.13.x` is the minimum required version. Node.js `18.12.x`, NPM `8.x` and later versions are recommended.
+Node.js `20` is the minimum required version. Node.js `22`, NPM `10` and later versions are recommended.
 
 ### Usage
 

--- a/docs/docs/usage/sdk/how-to-use.md
+++ b/docs/docs/usage/sdk/how-to-use.md
@@ -32,7 +32,7 @@ const { StreamrClient } = require('@streamr/sdk');
 ### Environments and frameworks
 
 #### NodeJS
-NodeJS `18.13.x` is the minimum required version, ideally version 20 and later. NodeJS, NPM `8.x` and later versions are recommended.
+NodeJS `20` is the minimum required version, ideally version 22 and later. NodeJS, NPM `10` and later versions are recommended.
 
 #### Browser (Website/WebApps)
 For usage in the browser include the latest build, e.g. by including a `<script>` tag pointing at a CDN:

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -18,7 +18,7 @@ See [Changelog](CHANGELOG.md) for version information and changes.
 ```
 npm install -g @streamr/cli-tools
 ```
-Node.js `16.13.x` is the minimum required version. Node.js `18.12.x`, NPM `8.x` and later versions are recommended.
+Node.js `20` is the minimum required version. Node.js `22`, NPM `10` and later versions are recommended.
 
 ## Use
 All commands follow pattern `streamr <command> <subcommand>`, e.g.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -37,7 +37,7 @@ const { StreamrClient } = require('@streamr/sdk')
 The Streamr SDK is built for the browser and NodeJS environments. 
 
 **NodeJS**
-- NodeJS `18.13.x`, NPM `8.x` and later versions are recommended.
+- NodeJS `20`, NPM `10` and later versions are recommended.
 
 **Browser (Website/WebApps)**
 - For usage in the browser include the latest build, e.g. by including a `<script>` tag pointing at a CDN:


### PR DESCRIPTION
**This is a breaking change as the environment prerequisites change.**

NodeJS v18 [has reach end-of-life recently](https://nodejs.org/en/about/previous-releases). Therefore we upgrade the minimum supported version and the preferred version. Also required/preferred NPM version is changed accordingly.

Note also that the `commander` package doesn't support NodeJS v18 anymore, see https://github.com/streamr-dev/network/pull/3130.

## Future improvements

The version information is in quite many places in our documentation. Maybe could avoid the duplication somehow.