### PR TITLE
feat(cli-tools): Internal `operator-update` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-operator-update.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-update.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import '../src/logLevel'
+
+import { EthereumAddress, StreamrClient, _operatorContractUtils } from '@streamr/sdk'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
+import { createFnParseEthereumAddressList, createFnParseInt } from '../src/common'
+
+interface Options extends BaseOptions {
+    redundancyFactor?: number
+    nodeAddresses?: EthereumAddress[]
+}
+
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, options: Options) => {
+    if ((options.redundancyFactor === undefined) && (options.nodeAddresses === undefined)) {
+        console.error('Nothing to update')
+        process.exit(1)
+    }
+    const contract = _operatorContractUtils.getOperatorContract(operatorContractAddress).connect(await client.getSigner())
+    if (options.redundancyFactor !== undefined) {
+        const existingMetadata = JSON.parse(await contract.metadata())
+        const metadata = {
+            ...existingMetadata,
+            redundancyFactor: options.redundancyFactor
+        }
+        await (await contract.updateMetadata(JSON.stringify(metadata))).wait()
+    }
+    if (options.nodeAddresses !== undefined) {
+        await (await contract.setNodeAddresses(options.nodeAddresses)).wait()
+    }
+})
+    .description('update operator')
+    .arguments('<operatorContractAddress>')
+    .option('-r, --redundancy-factor <number>', 'Redundancy factor',
+        createFnParseInt('--redundancy-factor'))
+    .option('-n, --node-addresses <addresses>', 'Node addresses (comma separated list of Ethereum addresses)', 
+        createFnParseEthereumAddressList('nodeAddresses'))
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal.ts
+++ b/packages/cli-tools/bin/streamr-internal.ts
@@ -12,6 +12,7 @@ program
     .command('sponsorship-create', 'create sponsorship')
     .command('sponsorship-sponsor', 'sponsor a sponsorship')
     .command('operator-create', 'create operator')
+    .command('operator-update', 'update operator')
     .command('operator-delegate', 'delegate funds to an operator')
     .command('operator-undelegate', 'undelegate funds from an operator')
     .command('operator-stake', 'stake operator\'s funds to a sponsorship')


### PR DESCRIPTION
Added new internal command for updating operator redundancy factor and/or node addresses.

## Future improvements

It is ok to promote this to a non-internal command.