### PR TITLE
fix(sdk): Use sponsorship contract in `unstake()`

### DIFF
--- a/packages/cli-tools/test/internal-operator.test.ts
+++ b/packages/cli-tools/test/internal-operator.test.ts
@@ -40,13 +40,13 @@ describe('operator', () => {
         await runCommand(`internal operator-stake ${operatorContractAddress} ${sponsorshipAddress} ${STAKE_AMOUNT}`, {
             privateKey: operator.privateKey
         })
-        expect(await operatorContract.totalStakedIntoSponsorshipsWei()).toEqual(parseEther(STAKE_AMOUNT))
+        expect(await sponsorshipContract.stakedWei(operatorContractAddress)).toEqual(parseEther(STAKE_AMOUNT))
 
         // unstake
         await runCommand(`internal operator-unstake ${operatorContractAddress} ${sponsorshipAddress} ${UNSTAKE_AMOUNT}`, {
             privateKey: operator.privateKey
         })
-        expect(await operatorContract.totalStakedIntoSponsorshipsWei()).toEqual(parseEther(STAKE_AMOUNT) - parseEther(UNSTAKE_AMOUNT))
+        expect(await sponsorshipContract.stakedWei(operatorContractAddress)).toEqual(parseEther(STAKE_AMOUNT) - parseEther(UNSTAKE_AMOUNT))
 
         // undelegate
         await wait(MINIMUM_DELEGATION_SECONDS)

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -158,10 +158,11 @@ export const unstake = async (
     amount: WeiAmount
 ): Promise<void> => {
     logger.debug('Unstake')
-    const contract = getOperatorContract(operatorContractAddress).connect(staker)
-    const currentAmount = await contract.stakedInto(sponsorshipContractAddress)
+    const operatorContract = getOperatorContract(operatorContractAddress).connect(staker)
+    const sponsorshipContract = getSponsorshipContract(sponsorshipContractAddress).connect(staker)
+    const currentAmount = await sponsorshipContract.stakedWei(operatorContractAddress)
     const targetAmount = currentAmount - amount
-    await (await contract.reduceStakeTo(sponsorshipContractAddress, targetAmount)).wait()
+    await (await operatorContract.reduceStakeTo(sponsorshipContractAddress, targetAmount)).wait()
 }
 
 export const sponsor = async (


### PR DESCRIPTION
Use sponsorship contract address to calculate the current balance, so that possible slashing amount is taken in to account. (the `Sponsorship.stakedWei` is equal to `Operator.stakedInto` - `Operator.slashedIn`)

## Other changes

Also improved assertion in `internal-operator.test.ts`