### PR TITLE
chore: Fix `@typescript-eslint/await-thenable` warnings

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -551,22 +551,22 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
 
     public async enablePrivateClientMode(): Promise<void> {
         this.privateClientMode = true
-        await Promise.all(Array.from(this.endpoints.values()).map((endpoint) => {
-            if (endpoint.connected) {
-                const peerDescription = endpoint.connection.getPeerDescriptor()
-                return this.setPrivateForConnection(peerDescription!, true)
-            }
+        await Promise.all(this.getConnectedEndpoints().map((endpoint) => {
+            const peerDescription = endpoint.connection.getPeerDescriptor()
+            return this.setPrivateForConnection(peerDescription!, true)
         }))
     }
 
     public async disablePrivateClientMode(): Promise<void> {
         this.privateClientMode = false
-        await Promise.all(Array.from(this.endpoints.values()).map((endpoint) => {
-            if (endpoint.connected) {
-                const peerDescription = endpoint.connection.getPeerDescriptor()
-                return this.setPrivateForConnection(peerDescription!, false)
-            }
+        await Promise.all(this.getConnectedEndpoints().map((endpoint) => {
+            const peerDescription = endpoint.connection.getPeerDescriptor()
+            return this.setPrivateForConnection(peerDescription!, false)
         }))
+    }
+
+    private getConnectedEndpoints(): Endpoint[] {
+        return Array.from(this.endpoints.values()).filter((endpoint) => endpoint.connected)
     }
 
     public isPrivateClientMode(): boolean {

--- a/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
@@ -111,7 +111,7 @@ export class WebsocketClientConnector {
         this.abortController.abort()
 
         const requests = Array.from(this.connectingConnections.values())
-        await Promise.allSettled(requests.map((conn) => conn.close(true)))
+        requests.forEach((conn) => conn.close(true))
 
         await this.websocketServer?.stop()
         this.geoIpLocator?.stop()

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -280,7 +280,7 @@ export class WebsocketServerConnector {
         this.abortController.abort()
 
         const requests = Array.from(this.ongoingConnectRequests.values())
-        await Promise.allSettled(requests.map((ongoingConnectRequest) => ongoingConnectRequest.pendingConnection.close(true)))
+        requests.forEach((ongoingConnectRequest) => ongoingConnectRequest.pendingConnection.close(true))
 
         await this.websocketServer?.stop()
         this.geoIpLocator?.stop()

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -61,7 +61,7 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)
@@ -74,12 +74,12 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
         ])
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock2')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)
@@ -92,7 +92,7 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)
@@ -110,12 +110,12 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
         ])
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock2')
         ])
 
@@ -136,9 +136,9 @@ describe('Connection Locking', () => {
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             until(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1'),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager2.lockConnection(mockPeerDescriptor1, 'testLock1')
         ])
 
@@ -163,9 +163,9 @@ describe('Connection Locking', () => {
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             until(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1'),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             connectionManager2.lockConnection(mockPeerDescriptor1, 'testLock1')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)

--- a/packages/sdk/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/sdk/test/integration/GroupKeyPersistence.test.ts
@@ -162,6 +162,7 @@ describe('Group Key Persistence', () => {
 
             await Promise.all([
                 collect(sub2, 3),
+                // eslint-disable-next-line @typescript-eslint/await-thenable
                 published.push(...await publishTestMessages(3)),
             ])
 

--- a/packages/sdk/test/integration/parallel-publish.test.ts
+++ b/packages/sdk/test/integration/parallel-publish.test.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata'
 import { wait } from '@streamr/utils'
 import random from 'lodash/random'
 import uniq from 'lodash/uniq'
+import range from 'lodash/range'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
@@ -29,16 +30,14 @@ describe('parallel publish', () => {
     })
 
     it('messages in order and in same chain', async () => {
-        const publishTasks = []
-        for (let i = 0; i < MESSAGE_COUNT; i++) {
-            const task = await publisher.publish(stream.id, {
+        const publishTasks = range(MESSAGE_COUNT).map(async (i) => {
+            await publisher.publish(stream.id, {
                 mockId: i
             })
-            publishTasks.push(task)
             if (Math.random() < 0.5) {
                 await wait(random(5))
             }
-        }
+        })
         await Promise.all(publishTasks)
 
         const sentMessages = await environment.getNetwork().waitForSentMessages({

--- a/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
@@ -106,15 +106,15 @@ describe('content delivery layer node with real connections', () => {
             dhtNode2.stop(),
             dhtNode3.stop(),
             dhtNode4.stop(),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             contentDeliveryLayerNode1.stop(),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             contentDeliveryLayerNode2.stop(),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             contentDeliveryLayerNode3.stop(),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             contentDeliveryLayerNode4.stop(),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             contentDeliveryLayerNode5.stop(),
             (epDhtNode.getTransport() as ConnectionManager).stop(),
             (dhtNode1.getTransport() as ConnectionManager).stop(),

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -107,7 +107,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
     it('happy path 64 nodes', async () => {
         await Promise.all(range(otherNodeCount).map((i) => otherContentDeliveryLayerNodes[i].start()))
         await Promise.all(range(otherNodeCount).map((i) => {
-            otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
+            return otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) =>
             until(() => node.getNeighbors().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -65,7 +65,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
         entryPointDiscoveryLayerNode.stop()
         entryPointContentDeliveryLayerNode.stop()
         await Promise.all(otherDiscoveryLayerNodes.map((node) => node.stop()))
-        await Promise.all(otherContentDeliveryLayerNodes.map((node) => node.stop()))
+        otherContentDeliveryLayerNodes.forEach((node) => node.stop())
     })
 
     it('happy path single node', async () => {

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -85,7 +85,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
         await entryPointDiscoveryLayerNode.stop()
         entryPointContentDeliveryLayerNode.stop()
         await Promise.all(otherDiscoveryLayerNodes.map((node) => node.stop()))
-        await Promise.all(otherContentDeliveryLayerNodes.map((node) => node.stop()))
+        otherContentDeliveryLayerNodes.forEach((node) => node.stop())
     })
 
     it('happy path single node ', async () => {

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -126,7 +126,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
     it('happy path 64 nodes', async () => {
         await Promise.all(range(otherNodeCount).map((i) => otherContentDeliveryLayerNodes[i].start()))
         await Promise.all(range(otherNodeCount).map((i) => {
-            otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
+            return otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) =>
             until(() => node.getNeighbors().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
@@ -97,7 +97,7 @@ describe('ContentDeliveryManager', () => {
         await until(() => manager2.getNeighbors(STREAM_PART_ID).length === 1)
         await Promise.all([
             waitForEvent(manager1, 'newMessage'),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             manager2.broadcast(msg)
         ])
     })
@@ -124,9 +124,9 @@ describe('ContentDeliveryManager', () => {
         await Promise.all([
             waitForEvent(manager1, 'newMessage'),
             waitForEvent(manager2, 'newMessage'),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             manager1.broadcast(msg2),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             manager2.broadcast(msg)
         ])
     })

--- a/packages/trackerless-network/test/integration/PlumTreePropagation.test.ts
+++ b/packages/trackerless-network/test/integration/PlumTreePropagation.test.ts
@@ -74,7 +74,7 @@ describe('Propagation', () => {
     }, 45000)
 
     afterEach(async () => {
-        await Promise.all(contentDeliveryLayerNodes.map((node) => node.stop()))
+        contentDeliveryLayerNodes.forEach((node) => node.stop())
         await Promise.all(discoveryLayerNodes.map((node) => node.stop()))
         simulator.stop()
     })

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -51,7 +51,7 @@ describe('Propagation', () => {
     }, 45000)
 
     afterEach(async () => {
-        await Promise.all(contentDeliveryLayerNodes.map((node) => node.stop()))
+        contentDeliveryLayerNodes.forEach((node) => node.stop())
         await Promise.all(discoveryLayerNodes.map((node) => node.stop()))
     })
 

--- a/packages/trackerless-network/test/unit/InspectSession.test.ts
+++ b/packages/trackerless-network/test/unit/InspectSession.test.ts
@@ -51,7 +51,7 @@ describe('InspectSession', () => {
         inspectSession.markMessage(anotherNode, messageId1)
         await Promise.all([
             waitForEvent(inspectSession, 'done', 100),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             inspectSession.markMessage(inspectedNode, messageId1)
         ])
         expect(inspectSession.getInspectedMessageCount()).toBe(1)
@@ -61,7 +61,7 @@ describe('InspectSession', () => {
         inspectSession.markMessage(inspectedNode, messageId1)
         await Promise.all([
             waitForEvent(inspectSession, 'done', 100),
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
             inspectSession.markMessage(anotherNode, messageId1)
         ])
         expect(inspectSession.getInspectedMessageCount()).toBe(1)
@@ -72,7 +72,7 @@ describe('InspectSession', () => {
         await expect(async () => {
             await Promise.all([
                 waitForEvent(inspectSession, 'done', 100),
-                // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+                // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression, @typescript-eslint/await-thenable
                 inspectSession.markMessage(anotherNode, messageId2)
             ])
         }).rejects.toThrow('waitForEvent')

--- a/packages/utils/src/pTransaction.ts
+++ b/packages/utils/src/pTransaction.ts
@@ -13,6 +13,7 @@ export async function pTransaction<T>(
         try {
             results.push(await promise)
         } catch (err) {
+            // eslint-disable-next-line @typescript-eslint/await-thenable
             await Promise.allSettled(results.map((r) => rollback(r)))
             throw err
         }


### PR DESCRIPTION
When we'll upgrade to `typescript-eslint` v8.44.0 in https://github.com/streamr-dev/network/pull/3208, the linter errors in some of our use cases. 

Fixed several issues and disabled certain warnings. See individual commit messages for details.
