### PR TITLE
refactor: Move process exit handlers from the trackerless-network to the node package

### DIFF
--- a/docs/docs/usage/sdk/how-to-use.md
+++ b/docs/docs/usage/sdk/how-to-use.md
@@ -29,6 +29,13 @@ If using Node.js you can import the library with:
 const { StreamrClient } = require('@streamr/sdk');
 ```
 
+After the StreamrClient is no longer needed or the process is shutting down it is very important to destroy the StreamrClient:
+
+```js
+const client = new StreamrClient()
+await client.destroy()
+```
+
 ### Environments and frameworks
 
 #### Node.js

--- a/docs/docs/usage/sdk/how-to-use.md
+++ b/docs/docs/usage/sdk/how-to-use.md
@@ -29,6 +29,8 @@ If using Node.js you can import the library with:
 const { StreamrClient } = require('@streamr/sdk');
 ```
 
+### Cleaning up
+
 After the StreamrClient is no longer needed or the process is shutting down it is very important to destroy the StreamrClient:
 
 ```js

--- a/packages/node/bin/streamr-node.ts
+++ b/packages/node/bin/streamr-node.ts
@@ -26,7 +26,7 @@ program
                 process.exit(exitCode)
             }
             
-            const exitEvents = ['SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2', 'exit']
+            const exitEvents = ['SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2']
             exitEvents.forEach((event) => {
                 process.on(event, () => shutdown(0))
             })

--- a/packages/node/src/broker.ts
+++ b/packages/node/src/broker.ts
@@ -78,13 +78,3 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
         }
     }
 }
-
-process.on('uncaughtException', (err) => {
-    logger.fatal('Encountered uncaughtException', { err })
-    process.exit(1)
-})
-
-process.on('unhandledRejection', (err) => {
-    logger.fatal('Encountered unhandledRejection', { err })
-    process.exit(1)
-})

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -119,7 +119,7 @@ streamr.resend(streamId, { last: 10 }, (msgs) => {
 ```
 
 ### Clean up
-After the StreamrClient is no longer used or the process is shutting down it is very important to call `destroy` on the StreamrClient. This ensures that the network node of the client will be shutdown gracefully. 
+After the `StreamrClient` is no longer used or the process is shutting down it is very important to call `destroy()` on the `StreamrClient`. This ensures that the network node of the client will be shutdown gracefully. 
 
 ```js
 await streamr.destroy()

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -118,6 +118,13 @@ streamr.resend(streamId, { last: 10 }, (msgs) => {
 });
 ```
 
+### Clean up
+After the StreamrClient is no longer used or the process is shutting down it is very important to call `destroy` on the StreamrClient. This ensures that the network node of the client will be shutdown gracefully. 
+
+```js
+await streamr.destroy()
+```
+
 ___
 
 **This Readme only scratches the surface of what's possible - be sure to [checkout our documentation](https://docs.streamr.network) for the full usage instructions.**

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -32,17 +32,6 @@ const stopInstances = async () => {
     const clonedInstances = [...instances]
     await Promise.all(clonedInstances.map((instance) => instance.stop()))
 }
-const EXIT_EVENTS = [`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `unhandledRejection`, `SIGTERM`]
-EXIT_EVENTS.forEach((event) => {
-    process.on(event, async (eventArg) => {
-        const isError = (event === 'uncaughtException') || (event === 'unhandledRejection')
-        if (isError) {
-            logger.error(`exit event: ${event}`, eventArg)
-        }
-        await stopInstances()
-        process.exit(isError ? 1 : 0)
-    })
-})
 declare let window: any
 if (typeof window === 'object') {
     window.addEventListener('unload', async () => {


### PR DESCRIPTION
## Summary

Moved exit handlers from the `trackerless-network` to the `node` package. This ensures that the operator nodes will still gracefully leave the network if the process is exited. Also removed the on unload event listener in NetworkStack. Users of the SDK are being made aware of the change by updating the SDK's README to include a section about properly cleaning up the Network node when the StreamrClient is no longer needed.

## Other Changes 

- The `exit` case is no longer handled as we cannot do asynchronous operations there.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move shutdown handling to the node CLI, remove global exit/unload handlers from trackerless-network, and document proper StreamrClient cleanup.
> 
> - **Node CLI (`packages/node/bin/streamr-node.ts`)**
>   - Add graceful shutdown handlers for `SIGINT`, `SIGTERM`, `SIGUSR1`, `SIGUSR2`.
>   - On `uncaughtException`/`unhandledRejection`, log fatal and stop broker before exit.
> - **Trackerless Network (`packages/trackerless-network/src/NetworkStack.ts`)**
>   - Remove global process/window exit handlers and instance tracking; simplify `stop()`.
> - **Docs**
>   - Add cleanup guidance to `docs/docs/usage/sdk/how-to-use.md` and `packages/sdk/README.md` to call `StreamrClient.destroy()` when done.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d88f0f5cb925fd43b48aa80f7440278bbbdd8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->