### PR TITLE
refactor: Offload AES encryption/decryption to Web Worker

### DIFF
--- a/packages/sdk/createKarmaConfig.ts
+++ b/packages/sdk/createKarmaConfig.ts
@@ -17,6 +17,7 @@ export function createKarmaConfig(testPaths: string[]): ReturnType<typeof create
                 '@streamr/dht': resolve(__dirname, '../dht/dist/exports-browser.cjs'),
                 "@/createSignatureValidationWorker": resolve(__dirname, 'src/_karma/createSignatureValidationWorker.ts'),
                 "@/createSigningWorker": resolve(__dirname, 'src/_karma/createSigningWorker.ts'),
+                "@/createEncryptionWorker": resolve(__dirname, 'src/_karma/createEncryptionWorker.ts'),
                 '@': resolve(__dirname, 'src/_browser'),
             },
             fallback: {

--- a/packages/sdk/jest.config.ts
+++ b/packages/sdk/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config.InitialOptions = {
     moduleNameMapper: {
         "^@/createSignatureValidationWorker$": "<rootDir>/src/_jest/createSignatureValidationWorker.ts",
         "^@/createSigningWorker$": "<rootDir>/src/_jest/createSigningWorker.ts",
+        "^@/createEncryptionWorker$": "<rootDir>/src/_jest/createEncryptionWorker.ts",
         "^@/(.*)$": "<rootDir>/src/_nodejs/$1",
     },
     transform: {

--- a/packages/sdk/rollup.config.mts
+++ b/packages/sdk/rollup.config.mts
@@ -36,6 +36,7 @@ const browserAliases: Alias[] = [
 const WORKERS: Record<string, string> = {
     'SignatureValidationWorker': 'signature/SignatureValidationWorker',
     'SigningWorker': 'signature/SigningWorker',
+    'EncryptionWorker': 'encryption/EncryptionWorker',
 }
 
 export default defineConfig([

--- a/packages/sdk/src/_browser/createEncryptionWorker.ts
+++ b/packages/sdk/src/_browser/createEncryptionWorker.ts
@@ -1,0 +1,11 @@
+/**
+ * Browser-specific encryption worker factory.
+ */
+import Worker from 'web-worker'
+
+export function createEncryptionWorker(): InstanceType<typeof Worker> {
+    return new Worker(
+        new URL('./workers/EncryptionWorker.browser.mjs', import.meta.url),
+        { type: 'module' }
+    )
+}

--- a/packages/sdk/src/_jest/createEncryptionWorker.ts
+++ b/packages/sdk/src/_jest/createEncryptionWorker.ts
@@ -1,0 +1,12 @@
+/**
+ * Jest-specific encryption worker factory.
+ * Points to the built worker in dist/ for testing.
+ */
+import Worker from 'web-worker'
+
+export function createEncryptionWorker(): InstanceType<typeof Worker> {
+    return new Worker(
+        new URL('../../dist/workers/EncryptionWorker.node.mjs', import.meta.url),
+        { type: 'module' }
+    )
+}

--- a/packages/sdk/src/_karma/createEncryptionWorker.ts
+++ b/packages/sdk/src/_karma/createEncryptionWorker.ts
@@ -1,0 +1,12 @@
+/**
+ * Karma-specific encryption worker factory.
+ * Points to the built worker in dist/ for browser testing.
+ */
+import Worker from 'web-worker'
+
+export function createEncryptionWorker(): InstanceType<typeof Worker> {
+    return new Worker(
+        new URL('../../dist/workers/EncryptionWorker.browser.mjs', import.meta.url),
+        { type: 'module' }
+    )
+}

--- a/packages/sdk/src/_nodejs/createEncryptionWorker.ts
+++ b/packages/sdk/src/_nodejs/createEncryptionWorker.ts
@@ -1,0 +1,11 @@
+/**
+ * Node.js-specific encryption worker factory.
+ */
+import Worker from 'web-worker'
+
+export function createEncryptionWorker(): InstanceType<typeof Worker> {
+    return new Worker(
+        new URL('./workers/EncryptionWorker.node.mjs', import.meta.url),
+        { type: 'module' }
+    )
+}

--- a/packages/sdk/src/encryption/EncryptionService.ts
+++ b/packages/sdk/src/encryption/EncryptionService.ts
@@ -1,0 +1,138 @@
+/**
+ * Singleton encryption service using Web Worker.
+ * This offloads CPU-intensive AES encryption operations to a separate thread.
+ * Works in both browser and Node.js environments via platform-specific config.
+ * 
+ * The worker is lazily initialized on first use and shared across all consumers.
+ */
+import { wrap, releaseProxy, transfer, type Remote } from 'comlink'
+import { Lifecycle, scoped } from 'tsyringe'
+import { EncryptedGroupKey } from '@streamr/trackerless-network'
+import { createEncryptionWorker } from '@/createEncryptionWorker'
+import type { EncryptionWorkerApi } from './EncryptionWorker'
+import { DestroySignal } from '../DestroySignal'
+import { StreamrClientError } from '../StreamrClientError'
+import { GroupKey } from './GroupKey'
+
+@scoped(Lifecycle.ContainerScoped)
+export class EncryptionService {
+    private worker: ReturnType<typeof createEncryptionWorker> | undefined
+    private workerApi: Remote<EncryptionWorkerApi> | undefined
+
+    constructor(destroySignal: DestroySignal) {
+        destroySignal.onDestroy.listen(() => this.destroy())
+    }
+
+    private getWorkerApi(): Remote<EncryptionWorkerApi> {
+        if (this.workerApi === undefined) {
+            this.worker = createEncryptionWorker()
+            this.workerApi = wrap<EncryptionWorkerApi>(this.worker)
+        }
+        return this.workerApi
+    }
+
+    /**
+     * Encrypt data using AES-256-CTR.
+     * Note: The input data buffer is transferred to the worker and becomes unusable after this call.
+     */
+    async encryptWithAES(data: Uint8Array, cipherKey: Uint8Array): Promise<Uint8Array> {
+        const result = await this.getWorkerApi().encrypt(
+            transfer({ data, cipherKey }, [data.buffer])
+        )
+        if (result.type === 'error') {
+            throw new Error(`AES encryption failed: ${result.message}`)
+        }
+        return result.data
+    }
+
+    /**
+     * Decrypt AES-256-CTR encrypted data.
+     * Note: The input cipher buffer is transferred to the worker and becomes unusable after this call.
+     */
+    async decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Promise<Uint8Array> {
+        const result = await this.getWorkerApi().decrypt(
+            transfer({ cipher, cipherKey }, [cipher.buffer])
+        )
+        if (result.type === 'error') {
+            throw new Error(`AES decryption failed: ${result.message}`)
+        }
+        return result.data
+    }
+
+    /**
+     * Encrypt the next group key using the current group key.
+     */
+    async encryptNextGroupKey(currentKey: GroupKey, nextKey: GroupKey): Promise<EncryptedGroupKey> {
+        const result = await this.getWorkerApi().encryptGroupKey({
+            nextGroupKeyId: nextKey.id,
+            nextGroupKeyData: nextKey.data,
+            currentGroupKeyData: currentKey.data
+        })
+        if (result.type === 'error') {
+            throw new Error(`Group key encryption failed: ${result.message}`)
+        }
+        return {
+            id: result.id,
+            data: result.data
+        }
+    }
+
+    /**
+     * Decrypt an encrypted group key using the current group key.
+     */
+    async decryptNextGroupKey(currentKey: GroupKey, encryptedKey: EncryptedGroupKey): Promise<GroupKey> {
+        const result = await this.getWorkerApi().decryptGroupKey({
+            encryptedGroupKeyId: encryptedKey.id,
+            encryptedGroupKeyData: encryptedKey.data,
+            currentGroupKeyData: currentKey.data
+        })
+        if (result.type === 'error') {
+            throw new Error(`Group key decryption failed: ${result.message}`)
+        }
+        return new GroupKey(result.id, Buffer.from(result.data))
+    }
+
+    /**
+     * Decrypt a stream message's content and optionally the new group key.
+     * This combines both operations for efficiency when processing messages.
+     * Note: The input content buffer is transferred to the worker and becomes unusable after this call.
+     */
+    async decryptStreamMessage(
+        content: Uint8Array,
+        groupKey: GroupKey,
+        encryptedNewGroupKey?: EncryptedGroupKey
+    ): Promise<[Uint8Array, GroupKey?]> {
+        const request = {
+            content,
+            groupKeyData: groupKey.data,
+            newGroupKey: encryptedNewGroupKey ? {
+                id: encryptedNewGroupKey.id,
+                data: encryptedNewGroupKey.data
+            } : undefined
+        }
+        const result = await this.getWorkerApi().decryptStreamMessage(
+            transfer(request, [content.buffer])
+        )
+        if (result.type === 'error') {
+            throw new StreamrClientError(`AES decryption failed: ${result.message}`, 'DECRYPT_ERROR')
+        }
+        
+        let newGroupKey: GroupKey | undefined
+        if (result.newGroupKey) {
+            newGroupKey = new GroupKey(result.newGroupKey.id, Buffer.from(result.newGroupKey.data))
+        }
+        
+        return [result.content, newGroupKey]
+    }
+
+    destroy(): void {
+        if (this.workerApi !== undefined) {
+            this.workerApi[releaseProxy]()
+            this.workerApi = undefined
+        }
+        if (this.worker !== undefined) {
+            this.worker.terminate()
+            this.worker = undefined
+        }
+    }
+}

--- a/packages/sdk/src/encryption/EncryptionService.ts
+++ b/packages/sdk/src/encryption/EncryptionService.ts
@@ -46,20 +46,6 @@ export class EncryptionService {
     }
 
     /**
-     * Decrypt AES-256-CTR encrypted data.
-     * Note: The input cipher buffer is transferred to the worker and becomes unusable after this call.
-     */
-    async decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Promise<Uint8Array> {
-        const result = await this.getWorkerApi().decrypt(
-            transfer({ cipher, cipherKey }, [cipher.buffer])
-        )
-        if (result.type === 'error') {
-            throw new Error(`AES decryption failed: ${result.message}`)
-        }
-        return result.data
-    }
-
-    /**
      * Encrypt the next group key using the current group key.
      */
     async encryptNextGroupKey(currentKey: GroupKey, nextKey: GroupKey): Promise<EncryptedGroupKey> {

--- a/packages/sdk/src/encryption/EncryptionUtil.ts
+++ b/packages/sdk/src/encryption/EncryptionUtil.ts
@@ -1,17 +1,19 @@
 import { ml_kem1024 } from '@noble/post-quantum/ml-kem'
 import { randomBytes } from '@noble/post-quantum/utils'
-import { StreamMessageAESEncrypted } from '../protocol/StreamMessage'
-import { StreamrClientError } from '../StreamrClientError'
-import { GroupKey } from './GroupKey'
 import { AsymmetricEncryptionType } from '@streamr/trackerless-network'
-import { binaryToUtf8, createCipheriv, createDecipheriv, getSubtle, privateDecrypt, publicEncrypt } from '@streamr/utils'
-
-export const INITIALIZATION_VECTOR_LENGTH = 16
+import { binaryToUtf8, getSubtle, privateDecrypt, publicEncrypt } from '@streamr/utils'
+import { decryptWithAES, encryptWithAES } from './aesUtils'
 
 const INFO = Buffer.from('streamr-key-exchange')
 const KEM_CIPHER_LENGTH_BYTES = 1568
 const KDF_SALT_LENGTH_BYTES = 64
 
+/**
+ * Asymmetric encryption utility class for RSA and ML-KEM (post-quantum) key exchange.
+ *
+ * For AES symmetric encryption of stream messages, use EncryptionService instead.
+ * This class only handles asymmetric encryption for key exchange operations.
+ */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class EncryptionUtil {
     /**
@@ -116,7 +118,7 @@ export class EncryptionUtil {
         const wrappingAESKey = await this.deriveAESWrapperKey(sharedSecret, kdfSalt)
         
         // Encrypt plaintext with the AES wrapping key
-        const aesEncryptedPlaintext = this.encryptWithAES(plaintextBuffer, Buffer.from(wrappingAESKey))
+        const aesEncryptedPlaintext = encryptWithAES(plaintextBuffer, Buffer.from(wrappingAESKey))
 
         // Concatenate the deliverables into a binary package
         return Buffer.concat([kemCipher, kdfSalt, aesEncryptedPlaintext])
@@ -138,44 +140,6 @@ export class EncryptionUtil {
         const wrappingAESKey = await this.deriveAESWrapperKey(sharedSecret, kdfSalt)
 
         // Decrypt the aesEncryptedPlaintext
-        return this.decryptWithAES(aesEncryptedPlaintext, Buffer.from(wrappingAESKey))
-    }
-
-    /*
-     * Returns a hex string without the '0x' prefix.
-     */
-    static encryptWithAES(data: Uint8Array, cipherKey: Uint8Array): Uint8Array {
-        const iv = randomBytes(INITIALIZATION_VECTOR_LENGTH) // always need a fresh IV when using CTR mode
-        const cipher = createCipheriv('aes-256-ctr', cipherKey, iv)
-        return Buffer.concat([iv, cipher.update(data), cipher.final()])
-    }
-
-    /*
-     * 'ciphertext' must be a hex string (without '0x' prefix), 'groupKey' must be a GroupKey. Returns a Buffer.
-     */
-    static decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Buffer {
-        const iv = cipher.slice(0, INITIALIZATION_VECTOR_LENGTH)
-        const decipher = createDecipheriv('aes-256-ctr', cipherKey, iv)
-        return Buffer.concat([decipher.update(cipher.slice(INITIALIZATION_VECTOR_LENGTH)), decipher.final()])
-    }
-
-    static decryptStreamMessage(streamMessage: StreamMessageAESEncrypted, groupKey: GroupKey): [Uint8Array, GroupKey?] | never {
-        let content: Uint8Array
-        try {
-            content = this.decryptWithAES(streamMessage.content, groupKey.data)
-        } catch {
-            throw new StreamrClientError('AES decryption failed', 'DECRYPT_ERROR', streamMessage)
-        }
-
-        let newGroupKey: GroupKey | undefined = undefined
-        if (streamMessage.newGroupKey) {
-            try {
-                newGroupKey = groupKey.decryptNextGroupKey(streamMessage.newGroupKey)
-            } catch {
-                throw new StreamrClientError('Could not decrypt new encryption key', 'DECRYPT_ERROR', streamMessage)
-            }
-        }
-
-        return [content, newGroupKey]
+        return decryptWithAES(aesEncryptedPlaintext, Buffer.from(wrappingAESKey))
     }
 }

--- a/packages/sdk/src/encryption/EncryptionUtil.ts
+++ b/packages/sdk/src/encryption/EncryptionUtil.ts
@@ -118,7 +118,7 @@ export class EncryptionUtil {
         const wrappingAESKey = await this.deriveAESWrapperKey(sharedSecret, kdfSalt)
         
         // Encrypt plaintext with the AES wrapping key
-        const aesEncryptedPlaintext = encryptWithAES(plaintextBuffer, Buffer.from(wrappingAESKey))
+        const aesEncryptedPlaintext = encryptWithAES(plaintextBuffer, wrappingAESKey)
 
         // Concatenate the deliverables into a binary package
         return Buffer.concat([kemCipher, kdfSalt, aesEncryptedPlaintext])
@@ -140,6 +140,6 @@ export class EncryptionUtil {
         const wrappingAESKey = await this.deriveAESWrapperKey(sharedSecret, kdfSalt)
 
         // Decrypt the aesEncryptedPlaintext
-        return decryptWithAES(aesEncryptedPlaintext, Buffer.from(wrappingAESKey))
+        return Buffer.from(decryptWithAES(aesEncryptedPlaintext, wrappingAESKey))
     }
 }

--- a/packages/sdk/src/encryption/EncryptionWorker.ts
+++ b/packages/sdk/src/encryption/EncryptionWorker.ts
@@ -3,18 +3,16 @@
  * Offloads CPU-intensive cryptographic operations to a separate thread.
  */
 import { expose, transfer } from 'comlink'
-import { decryptWithAES, encryptWithAES } from './aesUtils'
+import { encryptWithAES } from './aesUtils'
 import {
     encryptNextGroupKey,
     decryptNextGroupKey,
     decryptStreamMessageContent,
     AESEncryptRequest,
-    AESDecryptRequest,
     EncryptGroupKeyRequest,
     DecryptGroupKeyRequest,
     DecryptStreamMessageRequest,
     AESEncryptResult,
-    AESDecryptResult,
     EncryptGroupKeyResult,
     DecryptGroupKeyResult,
     DecryptStreamMessageResult
@@ -24,15 +22,6 @@ const workerApi = {
     encrypt: async (request: AESEncryptRequest): Promise<AESEncryptResult> => {
         try {
             const result = encryptWithAES(request.data, request.cipherKey)
-            return transfer({ type: 'success', data: result }, [result.buffer])
-        } catch (err) {
-            return { type: 'error', message: String(err) }
-        }
-    },
-
-    decrypt: async (request: AESDecryptRequest): Promise<AESDecryptResult> => {
-        try {
-            const result = decryptWithAES(request.cipher, request.cipherKey)
             return transfer({ type: 'success', data: result }, [result.buffer])
         } catch (err) {
             return { type: 'error', message: String(err) }

--- a/packages/sdk/src/encryption/EncryptionWorker.ts
+++ b/packages/sdk/src/encryption/EncryptionWorker.ts
@@ -1,0 +1,97 @@
+/**
+ * Web Worker for AES encryption operations.
+ * Offloads CPU-intensive cryptographic operations to a separate thread.
+ */
+import { expose, transfer } from 'comlink'
+import { decryptWithAES, encryptWithAES } from './aesUtils'
+import {
+    encryptNextGroupKey,
+    decryptNextGroupKey,
+    decryptStreamMessageContent,
+    AESEncryptRequest,
+    AESDecryptRequest,
+    EncryptGroupKeyRequest,
+    DecryptGroupKeyRequest,
+    DecryptStreamMessageRequest,
+    AESEncryptResult,
+    AESDecryptResult,
+    EncryptGroupKeyResult,
+    DecryptGroupKeyResult,
+    DecryptStreamMessageResult
+} from './encryptionUtils'
+
+const workerApi = {
+    encrypt: async (request: AESEncryptRequest): Promise<AESEncryptResult> => {
+        try {
+            const result = encryptWithAES(request.data, request.cipherKey)
+            return transfer({ type: 'success', data: result }, [result.buffer])
+        } catch (err) {
+            return { type: 'error', message: String(err) }
+        }
+    },
+
+    decrypt: async (request: AESDecryptRequest): Promise<AESDecryptResult> => {
+        try {
+            const result = decryptWithAES(request.cipher, request.cipherKey)
+            return transfer({ type: 'success', data: result }, [result.buffer])
+        } catch (err) {
+            return { type: 'error', message: String(err) }
+        }
+    },
+
+    encryptGroupKey: async (request: EncryptGroupKeyRequest): Promise<EncryptGroupKeyResult> => {
+        try {
+            const result = encryptNextGroupKey(
+                request.nextGroupKeyId,
+                request.nextGroupKeyData,
+                request.currentGroupKeyData
+            )
+            return transfer(
+                { type: 'success', id: result.id, data: result.data },
+                [result.data.buffer]
+            )
+        } catch (err) {
+            return { type: 'error', message: String(err) }
+        }
+    },
+
+    decryptGroupKey: async (request: DecryptGroupKeyRequest): Promise<DecryptGroupKeyResult> => {
+        try {
+            const result = decryptNextGroupKey(
+                request.encryptedGroupKeyId,
+                request.encryptedGroupKeyData,
+                request.currentGroupKeyData
+            )
+            return transfer(
+                { type: 'success', id: result.id, data: result.data },
+                [result.data.buffer]
+            )
+        } catch (err) {
+            return { type: 'error', message: String(err) }
+        }
+    },
+
+    decryptStreamMessage: async (request: DecryptStreamMessageRequest): Promise<DecryptStreamMessageResult> => {
+        try {
+            const result = decryptStreamMessageContent(
+                request.content,
+                request.groupKeyData,
+                request.newGroupKey
+            )
+            const transferables: ArrayBuffer[] = [result.content.buffer as ArrayBuffer]
+            if (result.newGroupKey) {
+                transferables.push(result.newGroupKey.data.buffer as ArrayBuffer)
+            }
+            return transfer(
+                { type: 'success', content: result.content, newGroupKey: result.newGroupKey },
+                transferables
+            )
+        } catch (err) {
+            return { type: 'error', message: String(err) }
+        }
+    }
+}
+
+export type EncryptionWorkerApi = typeof workerApi
+
+expose(workerApi)

--- a/packages/sdk/src/encryption/EncryptionWorker.ts
+++ b/packages/sdk/src/encryption/EncryptionWorker.ts
@@ -21,8 +21,8 @@ import {
 const workerApi = {
     encrypt: async (request: AESEncryptRequest): Promise<AESEncryptResult> => {
         try {
-            const result = encryptWithAES(request.data, request.cipherKey)
-            return transfer({ type: 'success', data: result }, [result.buffer])
+            const data = encryptWithAES(request.data, request.cipherKey)
+            return transfer({ type: 'success', data }, [data.buffer])
         } catch (err) {
             return { type: 'error', message: String(err) }
         }

--- a/packages/sdk/src/encryption/GroupKey.ts
+++ b/packages/sdk/src/encryption/GroupKey.ts
@@ -1,7 +1,6 @@
-import { EncryptedGroupKey } from '@streamr/trackerless-network'
-import { uuid } from '../utils/uuid'
-import { EncryptionUtil } from './EncryptionUtil'
 import { randomBytes } from '@noble/post-quantum/utils'
+import { uuid } from '../utils/uuid'
+
 export class GroupKeyError extends Error {
 
     public groupKey?: GroupKey
@@ -15,6 +14,9 @@ export class GroupKeyError extends Error {
 /**
  * GroupKeys are AES cipher keys, which are used to encrypt/decrypt StreamMessages (when encryptionType is AES).
  * Each group key contains 256 random bits of key data and an UUID.
+ *
+ * For encryption/decryption of group keys, use EncryptionService.encryptNextGroupKey()
+ * and EncryptionService.decryptNextGroupKey().
  */
 
 export class GroupKey {
@@ -67,21 +69,4 @@ export class GroupKey {
         const keyBytes = randomBytes(32)
         return new GroupKey(id, Buffer.from(keyBytes))
     }
-
-    /** @internal */
-    encryptNextGroupKey(nextGroupKey: GroupKey): EncryptedGroupKey {
-        return {
-            id: nextGroupKey.id, 
-            data: EncryptionUtil.encryptWithAES(nextGroupKey.data, this.data)
-        }
-    }
-
-    /** @internal */
-    decryptNextGroupKey(nextGroupKey: EncryptedGroupKey): GroupKey {
-        return new GroupKey(
-            nextGroupKey.id,
-            EncryptionUtil.decryptWithAES(nextGroupKey.data, this.data)
-        )
-    }
-
 }

--- a/packages/sdk/src/encryption/aesUtils.ts
+++ b/packages/sdk/src/encryption/aesUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * Low-level AES-256-CTR encryption utilities.
+ * Shared between EncryptionUtil (for ML-KEM key wrapping) and encryptionUtils (for stream message encryption).
+ */
+import { randomBytes } from '@noble/post-quantum/utils'
+import { createCipheriv, createDecipheriv } from '@streamr/utils'
+
+export const INITIALIZATION_VECTOR_LENGTH = 16
+
+/**
+ * Encrypt data using AES-256-CTR.
+ * Returns IV prepended to ciphertext.
+ */
+export function encryptWithAES(data: Uint8Array, cipherKey: Uint8Array): Uint8Array {
+    const iv = randomBytes(INITIALIZATION_VECTOR_LENGTH) // always need a fresh IV when using CTR mode
+    const cipher = createCipheriv('aes-256-ctr', cipherKey, iv)
+    return Buffer.concat([iv, cipher.update(data), cipher.final()])
+}
+
+/**
+ * Decrypt AES-256-CTR encrypted data.
+ * Expects IV prepended to ciphertext.
+ */
+export function decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Buffer {
+    const iv = cipher.slice(0, INITIALIZATION_VECTOR_LENGTH)
+    const decipher = createDecipheriv('aes-256-ctr', cipherKey, iv)
+    return Buffer.concat([decipher.update(cipher.slice(INITIALIZATION_VECTOR_LENGTH)), decipher.final()])
+}

--- a/packages/sdk/src/encryption/aesUtils.ts
+++ b/packages/sdk/src/encryption/aesUtils.ts
@@ -8,21 +8,35 @@ import { createCipheriv, createDecipheriv } from '@streamr/utils'
 export const INITIALIZATION_VECTOR_LENGTH = 16
 
 /**
+ * Concatenate multiple Uint8Arrays into a single Uint8Array.
+ */
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+    const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0)
+    const result = new Uint8Array(totalLength)
+    let offset = 0
+    for (const arr of arrays) {
+        result.set(arr, offset)
+        offset += arr.length
+    }
+    return result
+}
+
+/**
  * Encrypt data using AES-256-CTR.
  * Returns IV prepended to ciphertext.
  */
 export function encryptWithAES(data: Uint8Array, cipherKey: Uint8Array): Uint8Array {
     const iv = randomBytes(INITIALIZATION_VECTOR_LENGTH) // always need a fresh IV when using CTR mode
     const cipher = createCipheriv('aes-256-ctr', cipherKey, iv)
-    return Buffer.concat([iv, cipher.update(data), cipher.final()])
+    return concatBytes(iv, cipher.update(data), cipher.final())
 }
 
 /**
  * Decrypt AES-256-CTR encrypted data.
  * Expects IV prepended to ciphertext.
  */
-export function decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Buffer {
+export function decryptWithAES(cipher: Uint8Array, cipherKey: Uint8Array): Uint8Array {
     const iv = cipher.slice(0, INITIALIZATION_VECTOR_LENGTH)
     const decipher = createDecipheriv('aes-256-ctr', cipherKey, iv)
-    return Buffer.concat([decipher.update(cipher.slice(INITIALIZATION_VECTOR_LENGTH)), decipher.final()])
+    return concatBytes(decipher.update(cipher.slice(INITIALIZATION_VECTOR_LENGTH)), decipher.final())
 }

--- a/packages/sdk/src/encryption/encryptionUtils.ts
+++ b/packages/sdk/src/encryption/encryptionUtils.ts
@@ -14,11 +14,6 @@ export interface AESEncryptRequest {
     cipherKey: Uint8Array
 }
 
-export interface AESDecryptRequest {
-    cipher: Uint8Array
-    cipherKey: Uint8Array
-}
-
 export interface EncryptGroupKeyRequest {
     nextGroupKeyId: string
     nextGroupKeyData: Uint8Array
@@ -44,10 +39,6 @@ export interface DecryptStreamMessageRequest {
  * Result types for worker communication
  */
 export type AESEncryptResult =
-    | { type: 'success', data: Uint8Array }
-    | { type: 'error', message: string }
-
-export type AESDecryptResult =
     | { type: 'success', data: Uint8Array }
     | { type: 'error', message: string }
 

--- a/packages/sdk/src/encryption/encryptionUtils.ts
+++ b/packages/sdk/src/encryption/encryptionUtils.ts
@@ -1,0 +1,113 @@
+/**
+ * Higher-level encryption logic - shared between worker and main thread implementations.
+ * This file contains pure cryptographic functions without any network dependencies.
+ * 
+ * For low-level AES operations, see aesUtils.ts
+ */
+import { decryptWithAES, encryptWithAES } from './aesUtils'
+
+/**
+ * Request types for worker communication
+ */
+export interface AESEncryptRequest {
+    data: Uint8Array
+    cipherKey: Uint8Array
+}
+
+export interface AESDecryptRequest {
+    cipher: Uint8Array
+    cipherKey: Uint8Array
+}
+
+export interface EncryptGroupKeyRequest {
+    nextGroupKeyId: string
+    nextGroupKeyData: Uint8Array
+    currentGroupKeyData: Uint8Array
+}
+
+export interface DecryptGroupKeyRequest {
+    encryptedGroupKeyId: string
+    encryptedGroupKeyData: Uint8Array
+    currentGroupKeyData: Uint8Array
+}
+
+export interface DecryptStreamMessageRequest {
+    content: Uint8Array
+    groupKeyData: Uint8Array
+    newGroupKey?: {
+        id: string
+        data: Uint8Array
+    }
+}
+
+/**
+ * Result types for worker communication
+ */
+export type AESEncryptResult =
+    | { type: 'success', data: Uint8Array }
+    | { type: 'error', message: string }
+
+export type AESDecryptResult =
+    | { type: 'success', data: Uint8Array }
+    | { type: 'error', message: string }
+
+export type EncryptGroupKeyResult =
+    | { type: 'success', id: string, data: Uint8Array }
+    | { type: 'error', message: string }
+
+export type DecryptGroupKeyResult =
+    | { type: 'success', id: string, data: Uint8Array }
+    | { type: 'error', message: string }
+
+export type DecryptStreamMessageResult =
+    | { type: 'success', content: Uint8Array, newGroupKey?: { id: string, data: Uint8Array } }
+    | { type: 'error', message: string }
+
+/**
+ * Encrypt a next group key using the current group key.
+ */
+export function encryptNextGroupKey(
+    nextGroupKeyId: string,
+    nextGroupKeyData: Uint8Array,
+    currentGroupKeyData: Uint8Array
+): { id: string, data: Uint8Array } {
+    return {
+        id: nextGroupKeyId,
+        data: encryptWithAES(nextGroupKeyData, currentGroupKeyData)
+    }
+}
+
+/**
+ * Decrypt an encrypted group key using the current group key.
+ */
+export function decryptNextGroupKey(
+    encryptedGroupKeyId: string,
+    encryptedGroupKeyData: Uint8Array,
+    currentGroupKeyData: Uint8Array
+): { id: string, data: Uint8Array } {
+    return {
+        id: encryptedGroupKeyId,
+        data: decryptWithAES(encryptedGroupKeyData, currentGroupKeyData)
+    }
+}
+
+/**
+ * Decrypt a stream message content and optionally the new group key.
+ */
+export function decryptStreamMessageContent(
+    content: Uint8Array,
+    groupKeyData: Uint8Array,
+    newGroupKey?: { id: string, data: Uint8Array }
+): { content: Uint8Array, newGroupKey?: { id: string, data: Uint8Array } } {
+    const decryptedContent = decryptWithAES(content, groupKeyData)
+    
+    let decryptedNewGroupKey: { id: string, data: Uint8Array } | undefined
+    if (newGroupKey) {
+        decryptedNewGroupKey = decryptNextGroupKey(newGroupKey.id, newGroupKey.data, groupKeyData)
+    }
+    
+    return {
+        content: decryptedContent,
+        newGroupKey: decryptedNewGroupKey
+    }
+}

--- a/packages/sdk/src/protocol/StreamMessageTranslator.ts
+++ b/packages/sdk/src/protocol/StreamMessageTranslator.ts
@@ -86,10 +86,15 @@ export class StreamMessageTranslator {
         let groupKeyId: string | undefined = undefined
         if (msg.body.oneofKind === 'contentMessage') {
             messageType = StreamMessageType.MESSAGE
-            content = msg.body.contentMessage.content
+            content = new Uint8Array(msg.body.contentMessage.content)
             contentType = msg.body.contentMessage.contentType
             encryptionType = msg.body.contentMessage.encryptionType
-            newGroupKey = msg.body.contentMessage.newGroupKey
+            if (msg.body.contentMessage.newGroupKey) {
+                newGroupKey = {
+                    id: msg.body.contentMessage.newGroupKey.id,
+                    data: new Uint8Array(msg.body.contentMessage.newGroupKey.data)
+                }
+            }
             groupKeyId = msg.body.contentMessage.groupKeyId
         } else if (msg.body.oneofKind === 'groupKeyRequest') {
             messageType = StreamMessageType.GROUP_KEY_REQUEST
@@ -128,7 +133,7 @@ export class StreamMessageTranslator {
             messageType,
             content,
             contentType,
-            signature: msg.signature,
+            signature: new Uint8Array(msg.signature),
             signatureType: msg.signatureType,
             encryptionType,
             groupKeyId,

--- a/packages/sdk/src/publish/Publisher.ts
+++ b/packages/sdk/src/publish/Publisher.ts
@@ -8,6 +8,7 @@ import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamrClientError } from '../StreamrClientError'
 import { StreamRegistry } from '../contracts/StreamRegistry'
 import { getExplicitKey, GroupKeyManager } from '../encryption/GroupKeyManager'
+import { EncryptionService } from '../encryption/EncryptionService'
 import { StreamMessage } from '../protocol/StreamMessage'
 import { MessageSigner } from '../signature/MessageSigner'
 import { SignatureValidator } from '../signature/SignatureValidator'
@@ -54,6 +55,7 @@ export class Publisher {
     private readonly identity: Identity
     private readonly signatureValidator: SignatureValidator
     private readonly messageSigner: MessageSigner
+    private readonly encryptionService: EncryptionService
     private readonly config: StrictStreamrClientConfig
 
     constructor(
@@ -64,6 +66,7 @@ export class Publisher {
         @inject(IdentityInjectionToken) identity: Identity,
         signatureValidator: SignatureValidator,
         messageSigner: MessageSigner,
+        encryptionService: EncryptionService,
         @inject(ConfigInjectionToken) config: StrictStreamrClientConfig,
     ) {
         this.node = node
@@ -72,6 +75,7 @@ export class Publisher {
         this.identity = identity
         this.signatureValidator = signatureValidator
         this.messageSigner = messageSigner
+        this.encryptionService = encryptionService
         this.config = config
         this.messageFactories = createLazyMap({
             valueFactory: async (streamId) => {
@@ -142,6 +146,7 @@ export class Publisher {
             groupKeyQueue: await this.groupKeyQueues.get(streamId),
             signatureValidator: this.signatureValidator,
             messageSigner: this.messageSigner,
+            encryptionService: this.encryptionService,
             config: this.config,
         })
     }

--- a/packages/sdk/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/sdk/src/subscribe/MessagePipelineFactory.ts
@@ -6,6 +6,7 @@ import { DestroySignal } from '../DestroySignal'
 import { StreamRegistry } from '../contracts/StreamRegistry'
 import { StreamStorageRegistry } from '../contracts/StreamStorageRegistry'
 import { GroupKeyManager } from '../encryption/GroupKeyManager'
+import { EncryptionService } from '../encryption/EncryptionService'
 import { StreamMessage } from '../protocol/StreamMessage'
 import { SignatureValidator } from '../signature/SignatureValidator'
 import { LoggerFactory } from '../utils/LoggerFactory'
@@ -17,6 +18,7 @@ import { Tokens } from '../tokens'
 type MessagePipelineFactoryOptions = MarkOptional<Omit<MessagePipelineOptions,
     'resends' |
     'groupKeyManager' |
+    'encryptionService' |
     'streamRegistry' |
     'signatureValidator' |
     'destroySignal' |
@@ -32,6 +34,7 @@ export class MessagePipelineFactory {
     private readonly streamRegistry: StreamRegistry
     private readonly signatureValidator: SignatureValidator
     private readonly groupKeyManager: GroupKeyManager
+    private readonly encryptionService: EncryptionService
     private readonly config: MessagePipelineOptions['config']
     private readonly destroySignal: DestroySignal
     private readonly loggerFactory: LoggerFactory
@@ -43,6 +46,7 @@ export class MessagePipelineFactory {
         @inject(delay(() => StreamRegistry)) streamRegistry: StreamRegistry,
         signatureValidator: SignatureValidator,
         @inject(delay(() => GroupKeyManager)) groupKeyManager: GroupKeyManager,
+        encryptionService: EncryptionService,
         @inject(ConfigInjectionToken) config: MessagePipelineOptions['config'],
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory
@@ -52,6 +56,7 @@ export class MessagePipelineFactory {
         this.streamRegistry = streamRegistry
         this.signatureValidator = signatureValidator
         this.groupKeyManager = groupKeyManager
+        this.encryptionService = encryptionService
         this.config = config
         this.destroySignal = destroySignal
         this.loggerFactory = loggerFactory
@@ -65,6 +70,7 @@ export class MessagePipelineFactory {
             streamRegistry: this.streamRegistry,
             signatureValidator: this.signatureValidator,
             groupKeyManager: this.groupKeyManager,
+            encryptionService: this.encryptionService,
             config: opts.config ?? this.config,
             destroySignal: this.destroySignal,
             loggerFactory: this.loggerFactory

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -6,6 +6,7 @@ import type { StrictStreamrClientConfig } from '../ConfigTypes'
 import { DestroySignal } from '../DestroySignal'
 import { StreamRegistry } from '../contracts/StreamRegistry'
 import { GroupKeyManager } from '../encryption/GroupKeyManager'
+import { EncryptionService } from '../encryption/EncryptionService'
 import { decrypt } from '../encryption/decrypt'
 import { StreamMessage } from '../protocol/StreamMessage'
 
@@ -28,6 +29,7 @@ export interface MessagePipelineOptions {
     streamRegistry: StreamRegistry
     signatureValidator: SignatureValidator
     groupKeyManager: GroupKeyManager
+    encryptionService: EncryptionService
     // eslint-disable-next-line max-len
     config: Pick<StrictStreamrClientConfig, 'encryption' | 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy' | 'validation'>
     destroySignal: DestroySignal
@@ -71,7 +73,7 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): PushPipelin
         let decrypted
         if (StreamMessage.isAESEncrypted(msg)) {
             try {
-                decrypted = await decrypt(msg, opts.groupKeyManager, opts.destroySignal)
+                decrypted = await decrypt(msg, opts.groupKeyManager, opts.encryptionService, opts.destroySignal)
             } catch (err) {
                 // TODO log this in onError? if we want to log all errors?
                 logger.debug('Failed to decrypt', { messageId: msg.messageId, err })

--- a/packages/sdk/test/integration/Resends.test.ts
+++ b/packages/sdk/test/integration/Resends.test.ts
@@ -8,7 +8,7 @@ import { StreamPermission } from '../../src/permission'
 import { MessageFactory } from '../../src/publish/MessageFactory'
 import { SignatureValidator } from '../../src/signature/SignatureValidator'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
-import { createGroupKeyQueue, createMessageSigner, createStreamRegistry } from '../test-utils/utils'
+import { createGroupKeyQueue, createMessageSigner, createMockEncryptionService, createStreamRegistry } from '../test-utils/utils'
 import { EthereumKeyPairIdentity } from '../../src/identity/EthereumKeyPairIdentity'
 import { createStrictConfig } from '../../src/Config'
 
@@ -45,6 +45,7 @@ describe('Resends', () => {
             groupKeyQueue: await createGroupKeyQueue(identity, groupKey),
             signatureValidator: mock<SignatureValidator>(),
             messageSigner: createMessageSigner(identity),
+            encryptionService: createMockEncryptionService(),
             config: createStrictConfig()
         })
         // store the encryption key publisher's local group key store

--- a/packages/sdk/test/integration/gap-fill.test.ts
+++ b/packages/sdk/test/integration/gap-fill.test.ts
@@ -6,7 +6,14 @@ import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamMessage } from '../../src/protocol/StreamMessage'
 import { SignatureValidator } from '../../src/signature/SignatureValidator'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
-import { createGroupKeyQueue, createMessageSigner, createStreamRegistry, createTestStream, startFailingStorageNode } from '../test-utils/utils'
+import {
+    createGroupKeyQueue,
+    createMessageSigner,
+    createMockEncryptionService,
+    createStreamRegistry,
+    createTestStream,
+    startFailingStorageNode
+} from '../test-utils/utils'
 import { Stream } from './../../src/Stream'
 import { MessageFactory } from './../../src/publish/MessageFactory'
 import { EthereumKeyPairIdentity } from '../../src/identity/EthereumKeyPairIdentity'
@@ -45,6 +52,7 @@ describe('gap fill', () => {
             groupKeyQueue: await createGroupKeyQueue(identity, GROUP_KEY),
             signatureValidator: mock<SignatureValidator>(),
             messageSigner: createMessageSigner(identity),
+            encryptionService: createMockEncryptionService(),
             config: createStrictConfig()
         })
     })

--- a/packages/sdk/test/integration/parallel-key-exchange.test.ts
+++ b/packages/sdk/test/integration/parallel-key-exchange.test.ts
@@ -10,7 +10,7 @@ import { StreamPermission } from '../../src/permission'
 import { StreamMessageType } from '../../src/protocol/StreamMessage'
 import { MessageFactory } from '../../src/publish/MessageFactory'
 import { SignatureValidator } from '../../src/signature/SignatureValidator'
-import { createGroupKeyQueue, createMessageSigner, createStreamRegistry } from '../test-utils/utils'
+import { createGroupKeyQueue, createMessageSigner, createMockEncryptionService, createStreamRegistry } from '../test-utils/utils'
 import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
 import { EthereumKeyPairIdentity } from '../../src/identity/EthereumKeyPairIdentity'
 import { createStrictConfig } from '../../src/Config'
@@ -73,6 +73,7 @@ describe('parallel key exchange', () => {
                 groupKeyQueue: await createGroupKeyQueue(identity, publisher.groupKey),
                 signatureValidator: mock<SignatureValidator>(),
                 messageSigner: createMessageSigner(identity),
+                encryptionService: createMockEncryptionService(),
                 config: createStrictConfig()
             })
             for (let i = 0; i < MESSAGE_COUNT_PER_PUBLISHER; i++) {

--- a/packages/sdk/test/integration/update-encryption-key.test.ts
+++ b/packages/sdk/test/integration/update-encryption-key.test.ts
@@ -24,7 +24,7 @@ describe('update encryption key', () => {
         publisher = environment.createClient()
         subscriber = environment.createClient({
             encryption: {
-                keyRequestTimeout: 1000
+                keyRequestTimeout: 5000
             }
         })
         const stream = await publisher.createStream('/path')

--- a/packages/sdk/test/test-utils/fake/FakeEnvironment.ts
+++ b/packages/sdk/test/test-utils/fake/FakeEnvironment.ts
@@ -22,6 +22,7 @@ import { FakeStreamRegistry } from './FakeStreamRegistry'
 import { FakeStreamStorageRegistry } from './FakeStreamStorageRegistry'
 import { DestroySignal } from '../../../src/DestroySignal'
 import { SigningService } from '../../../src/signature/SigningService'
+import { EncryptionService } from '../../../src/encryption/EncryptionService'
 
 const DEFAULT_CLIENT_OPTIONS: StreamrClientConfig = {
     encryption: {
@@ -37,6 +38,7 @@ export class FakeEnvironment {
     private dependencyContainer: DependencyContainer
     private destroySignal: DestroySignal
     private signingService: SigningService
+    private encryptionService: EncryptionService
 
     constructor() {
         this.network = new FakeNetwork()
@@ -45,6 +47,7 @@ export class FakeEnvironment {
         this.dependencyContainer = container.createChildContainer()
         this.destroySignal = new DestroySignal()
         this.signingService = new SigningService(this.destroySignal)
+        this.encryptionService = new EncryptionService(this.destroySignal)
         const loggerFactory = {
             createLogger: () => this.logger
         }
@@ -58,6 +61,7 @@ export class FakeEnvironment {
         this.dependencyContainer.register(StorageNodeRegistry, FakeStorageNodeRegistry as any)
         this.dependencyContainer.register(OperatorRegistry, FakeOperatorRegistry as any)
         this.dependencyContainer.register(SigningService, { useValue: this.signingService })
+        this.dependencyContainer.register(EncryptionService, { useValue: this.encryptionService })
     }
 
     createClient(opts?: StreamrClientConfig): StreamrClient {

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -45,7 +45,7 @@ import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
 import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
 import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
 import { EncryptionService } from '../../src/encryption/EncryptionService'
-import { encryptWithAES, decryptWithAES } from '../../src/encryption/aesUtils'
+import { encryptWithAES } from '../../src/encryption/aesUtils'
 import { encryptNextGroupKey, decryptNextGroupKey, decryptStreamMessageContent } from '../../src/encryption/encryptionUtils'
 import { StreamrClientEventEmitter } from '../../src/events'
 import { StreamMessage } from '../../src/protocol/StreamMessage'
@@ -91,9 +91,6 @@ export function createMockEncryptionService(): EncryptionService {
     return {
         encryptWithAES: async (data: Uint8Array, cipherKey: Uint8Array) => {
             return encryptWithAES(data, cipherKey)
-        },
-        decryptWithAES: async (cipher: Uint8Array, cipherKey: Uint8Array) => {
-            return decryptWithAES(cipher, cipherKey)
         },
         encryptNextGroupKey: async (currentKey: GroupKey, nextKey: GroupKey) => {
             return encryptNextGroupKey(nextKey.id, nextKey.data, currentKey.data)

--- a/packages/sdk/test/unit/Decrypt.test.ts
+++ b/packages/sdk/test/unit/Decrypt.test.ts
@@ -6,7 +6,7 @@ import { StreamrClientError } from '../../src/StreamrClientError'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
 import { decrypt } from '../../src/encryption/decrypt'
-import { createGroupKeyManager, createMockMessage } from '../test-utils/utils'
+import { createGroupKeyManager, createMockEncryptionService, createMockMessage } from '../test-utils/utils'
 import { StreamMessage, StreamMessageAESEncrypted } from './../../src/protocol/StreamMessage'
 import { EncryptionType } from '@streamr/trackerless-network'
 import { EthereumKeyPairIdentity } from '../../src/identity/EthereumKeyPairIdentity'
@@ -26,7 +26,7 @@ describe('Decrypt', () => {
             encryptionKey: groupKey,
             content: unencryptedContent
         }) as StreamMessageAESEncrypted
-        const decryptedMessage = await decrypt(encryptedMessage, groupKeyManager, destroySignal)
+        const decryptedMessage = await decrypt(encryptedMessage, groupKeyManager, createMockEncryptionService(), destroySignal)
         expect(decryptedMessage).toEqual(new StreamMessage({
             ...encryptedMessage,
             encryptionType: EncryptionType.NONE,
@@ -53,6 +53,7 @@ describe('Decrypt', () => {
             return decrypt(
                 msg as StreamMessageAESEncrypted,
                 groupKeyManager,
+                createMockEncryptionService(),
                 destroySignal)
         }).rejects.toThrowStreamrClientError(
             new StreamrClientError(`Could not get encryption key ${groupKey.id}`, 'DECRYPT_ERROR', msg)

--- a/packages/sdk/test/unit/EncryptionService.test.ts
+++ b/packages/sdk/test/unit/EncryptionService.test.ts
@@ -18,7 +18,7 @@ describe('EncryptionService', () => {
         encryptionService.destroy()
     })
 
-    describe('encryptWithAES / decryptWithAES', () => {
+    describe('encryptWithAES', () => {
         it('encrypts and decrypts data correctly', async () => {
             const plaintextOriginal = utf8ToBinary('hello world')
             const key = GroupKey.generate()
@@ -32,7 +32,8 @@ describe('EncryptionService', () => {
             expect(ciphertext).not.toStrictEqual(plaintextOriginal)
             expect(ciphertext.length).toBeGreaterThan(plaintextOriginal.length)
 
-            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+            // Use decryptStreamMessage to verify encryption worked correctly
+            const [decrypted] = await encryptionService.decryptStreamMessage(ciphertext, key)
             
             expect(decrypted).toStrictEqual(plaintextOriginal)
         })
@@ -55,7 +56,7 @@ describe('EncryptionService', () => {
                 Uint8Array.from(plaintextOriginal), 
                 key.data
             )
-            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+            const [decrypted] = await encryptionService.decryptStreamMessage(ciphertext, key)
 
             expect(decrypted).toStrictEqual(plaintextOriginal)
         })
@@ -68,7 +69,7 @@ describe('EncryptionService', () => {
                 Uint8Array.from(plaintextOriginal), 
                 key.data
             )
-            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+            const [decrypted] = await encryptionService.decryptStreamMessage(ciphertext, key)
 
             expect(decrypted).toStrictEqual(plaintextOriginal)
         })
@@ -200,7 +201,7 @@ describe('EncryptionService', () => {
                     Uint8Array.from(plaintext), 
                     key.data
                 )
-                const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+                const [decrypted] = await encryptionService.decryptStreamMessage(ciphertext, key)
                 results.push(decrypted)
             }
 

--- a/packages/sdk/test/unit/EncryptionService.test.ts
+++ b/packages/sdk/test/unit/EncryptionService.test.ts
@@ -1,0 +1,213 @@
+import { utf8ToBinary } from '@streamr/utils'
+import { EncryptionService } from '../../src/encryption/EncryptionService'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { DestroySignal } from '../../src/DestroySignal'
+import { StreamrClientError } from '../../src/StreamrClientError'
+
+describe('EncryptionService', () => {
+
+    let encryptionService: EncryptionService
+    let destroySignal: DestroySignal
+
+    beforeEach(() => {
+        destroySignal = new DestroySignal()
+        encryptionService = new EncryptionService(destroySignal)
+    })
+
+    afterEach(() => {
+        encryptionService.destroy()
+    })
+
+    describe('encryptWithAES / decryptWithAES', () => {
+        it('encrypts and decrypts data correctly', async () => {
+            const plaintextOriginal = utf8ToBinary('hello world')
+            const key = GroupKey.generate()
+
+            // Make a copy since the original will be transferred
+            const ciphertext = await encryptionService.encryptWithAES(
+                Uint8Array.from(plaintextOriginal), 
+                key.data
+            )
+            
+            expect(ciphertext).not.toStrictEqual(plaintextOriginal)
+            expect(ciphertext.length).toBeGreaterThan(plaintextOriginal.length)
+
+            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+            
+            expect(decrypted).toStrictEqual(plaintextOriginal)
+        })
+
+        it('produces different ciphertexts for same plaintext (due to random IV)', async () => {
+            const plaintext = utf8ToBinary('hello world')
+            const key = GroupKey.generate()
+
+            const cipher1 = await encryptionService.encryptWithAES(Uint8Array.from(plaintext), key.data)
+            const cipher2 = await encryptionService.encryptWithAES(Uint8Array.from(plaintext), key.data)
+
+            expect(cipher1).not.toStrictEqual(cipher2)
+        })
+
+        it('handles empty data', async () => {
+            const plaintextOriginal = new Uint8Array(0)
+            const key = GroupKey.generate()
+
+            const ciphertext = await encryptionService.encryptWithAES(
+                Uint8Array.from(plaintextOriginal), 
+                key.data
+            )
+            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+
+            expect(decrypted).toStrictEqual(plaintextOriginal)
+        })
+
+        it('handles large data', async () => {
+            const plaintextOriginal = new Uint8Array(100000).fill(42)
+            const key = GroupKey.generate()
+
+            const ciphertext = await encryptionService.encryptWithAES(
+                Uint8Array.from(plaintextOriginal), 
+                key.data
+            )
+            const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+
+            expect(decrypted).toStrictEqual(plaintextOriginal)
+        })
+    })
+
+    describe('encryptNextGroupKey / decryptNextGroupKey', () => {
+        it('encrypts and decrypts group key correctly', async () => {
+            const currentKey = GroupKey.generate()
+            const nextKey = GroupKey.generate()
+
+            const encrypted = await encryptionService.encryptNextGroupKey(currentKey, nextKey)
+            
+            expect(encrypted.id).toBe(nextKey.id)
+            expect(encrypted.data).not.toStrictEqual(nextKey.data)
+
+            const decrypted = await encryptionService.decryptNextGroupKey(currentKey, encrypted)
+            
+            expect(decrypted.id).toBe(nextKey.id)
+            expect(decrypted.data).toStrictEqual(nextKey.data)
+        })
+
+        it('produces different ciphertexts for same key (due to random IV)', async () => {
+            const currentKey = GroupKey.generate()
+            const nextKey = GroupKey.generate()
+
+            const encrypted1 = await encryptionService.encryptNextGroupKey(currentKey, nextKey)
+            const encrypted2 = await encryptionService.encryptNextGroupKey(currentKey, nextKey)
+
+            expect(encrypted1.data).not.toStrictEqual(encrypted2.data)
+        })
+    })
+
+    describe('decryptStreamMessage', () => {
+        it('decrypts content without new group key', async () => {
+            const groupKey = GroupKey.generate()
+            const plaintextOriginal = utf8ToBinary('{"message": "hello"}')
+
+            const ciphertext = await encryptionService.encryptWithAES(
+                Uint8Array.from(plaintextOriginal), 
+                groupKey.data
+            )
+
+            const [decryptedContent, newGroupKey] = await encryptionService.decryptStreamMessage(
+                ciphertext,
+                groupKey
+            )
+
+            expect(decryptedContent).toStrictEqual(plaintextOriginal)
+            expect(newGroupKey).toBeUndefined()
+        })
+
+        it('decrypts content with new group key', async () => {
+            const currentKey = GroupKey.generate()
+            const nextKey = GroupKey.generate()
+            const plaintextOriginal = utf8ToBinary('{"message": "hello"}')
+
+            const ciphertext = await encryptionService.encryptWithAES(
+                Uint8Array.from(plaintextOriginal), 
+                currentKey.data
+            )
+            const encryptedNextKey = await encryptionService.encryptNextGroupKey(currentKey, nextKey)
+
+            const [decryptedContent, decryptedNewGroupKey] = await encryptionService.decryptStreamMessage(
+                ciphertext,
+                currentKey,
+                encryptedNextKey
+            )
+
+            expect(decryptedContent).toStrictEqual(plaintextOriginal)
+            expect(decryptedNewGroupKey).toBeDefined()
+            expect(decryptedNewGroupKey!.id).toBe(nextKey.id)
+            expect(decryptedNewGroupKey!.data).toStrictEqual(nextKey.data)
+        })
+
+        it('throws StreamrClientError on invalid encrypted content', async () => {
+            const groupKey = GroupKey.generate()
+            // Content that's too short to contain valid IV + ciphertext
+            const invalidContent = new Uint8Array([1, 2, 3])
+
+            await expect(encryptionService.decryptStreamMessage(invalidContent, groupKey))
+                .rejects
+                .toThrow(StreamrClientError)
+        })
+    })
+
+    describe('lifecycle', () => {
+        it('cleans up worker on destroy', async () => {
+            const plaintext = utf8ToBinary('test')
+            const key = GroupKey.generate()
+
+            // First encrypt to ensure worker is created
+            await encryptionService.encryptWithAES(Uint8Array.from(plaintext), key.data)
+
+            // Destroy should not throw
+            expect(() => encryptionService.destroy()).not.toThrow()
+
+            // Calling destroy again should be safe (idempotent)
+            expect(() => encryptionService.destroy()).not.toThrow()
+        })
+
+        it('cleans up via DestroySignal', async () => {
+            const plaintext = utf8ToBinary('test')
+            const key = GroupKey.generate()
+
+            await encryptionService.encryptWithAES(Uint8Array.from(plaintext), key.data)
+
+            // Trigger destroy via signal - should not throw
+            await destroySignal.destroy()
+        })
+
+        it('lazily initializes worker on first use', async () => {
+            // Create a new service but don't use it yet
+            const signal = new DestroySignal()
+            const service = new EncryptionService(signal)
+
+            // Destroy without using - should not throw
+            expect(() => service.destroy()).not.toThrow()
+        })
+    })
+
+    describe('sequential operations', () => {
+        it('can perform multiple operations sequentially', async () => {
+            const key = GroupKey.generate()
+            const results: Uint8Array[] = []
+
+            for (let i = 0; i < 5; i++) {
+                const plaintext = utf8ToBinary(`message ${i}`)
+                const ciphertext = await encryptionService.encryptWithAES(
+                    Uint8Array.from(plaintext), 
+                    key.data
+                )
+                const decrypted = await encryptionService.decryptWithAES(ciphertext, key.data)
+                results.push(decrypted)
+            }
+
+            expect(results).toHaveLength(5)
+            for (let i = 0; i < 5; i++) {
+                expect(results[i]).toStrictEqual(utf8ToBinary(`message ${i}`))
+            }
+        })
+    })
+})

--- a/packages/sdk/test/unit/EncryptionUtil.test.ts
+++ b/packages/sdk/test/unit/EncryptionUtil.test.ts
@@ -17,7 +17,7 @@ describe('EncryptionUtil', () => {
         it('returns the initial plaintext after decrypting the ciphertext', async () => {
             const key = await RSAKeyPair.create(512)
             const ciphertext = await EncryptionUtil.encryptForPublicKey(plaintext, key.getPublicKey(), AsymmetricEncryptionType.RSA)
-            expect(await EncryptionUtil.decryptWithPrivateKey(ciphertext, key.getPrivateKey(), AsymmetricEncryptionType.RSA)).toStrictEqual(plaintext)
+            expect(await EncryptionUtil.decryptWithPrivateKey(ciphertext, key.getPrivateKey(), AsymmetricEncryptionType.RSA)).toEqualBinary(plaintext)
         })
     
         it('produces different ciphertexts upon multiple encrypt() calls', async () => {
@@ -40,7 +40,7 @@ describe('EncryptionUtil', () => {
             const ciphertext = await EncryptionUtil.encryptForPublicKey(plaintext, key.getPublicKey(), AsymmetricEncryptionType.ML_KEM)
             expect(await EncryptionUtil.decryptWithPrivateKey(
                 ciphertext, key.getPrivateKey(), AsymmetricEncryptionType.ML_KEM
-            )).toStrictEqual(plaintext)
+            )).toEqualBinary(plaintext)
         })
     
         it('produces different ciphertexts upon multiple encrypt() calls', async () => {

--- a/packages/sdk/test/unit/EncryptionUtil.test.ts
+++ b/packages/sdk/test/unit/EncryptionUtil.test.ts
@@ -1,47 +1,11 @@
-import { createTestWallet } from '@streamr/test-utils'
-import { StreamPartIDUtils, hexToBinary, toStreamID, toStreamPartID, utf8ToBinary } from '@streamr/utils'
-import { EncryptionUtil, INITIALIZATION_VECTOR_LENGTH } from '../../src/encryption/EncryptionUtil'
-import { GroupKey } from '../../src/encryption/GroupKey'
-import { StreamrClientError } from '../../src/StreamrClientError'
-import { createMockMessage } from '../test-utils/utils'
-import { StreamMessage, StreamMessageAESEncrypted } from './../../src/protocol/StreamMessage'
 import { AsymmetricEncryptionType } from '@streamr/trackerless-network'
-import { RSAKeyPair } from '../../src/encryption/RSAKeyPair'
+import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
 import { MLKEMKeyPair } from '../../src/encryption/MLKEMKeyPair'
-
-const STREAM_ID = toStreamID('streamId')
+import { RSAKeyPair } from '../../src/encryption/RSAKeyPair'
 
 describe('EncryptionUtil', () => {
 
     const plaintext = Buffer.from('some random text', 'utf8')
-
-    describe('AES', () => {
-        it('returns a ciphertext which is different from the plaintext', () => {
-            const key = GroupKey.generate()
-            const ciphertext = EncryptionUtil.encryptWithAES(plaintext, key.data)
-            expect(ciphertext).not.toStrictEqual(plaintext)
-        })
-
-        it('returns the initial plaintext after decrypting the ciphertext', () => {
-            const key = GroupKey.generate()
-            const ciphertext = EncryptionUtil.encryptWithAES(plaintext, key.data)
-            expect(EncryptionUtil.decryptWithAES(ciphertext, key.data)).toStrictEqual(plaintext)
-        })
-    
-        it('preserves size (plaintext + iv)', () => {
-            const key = GroupKey.generate()
-            const ciphertext = EncryptionUtil.encryptWithAES(plaintext, key.data)
-            expect(ciphertext.length).toStrictEqual(plaintext.length + INITIALIZATION_VECTOR_LENGTH)
-        })
-    
-        it('produces different ivs and ciphertexts upon multiple encrypt() calls', () => {
-            const key = GroupKey.generate()
-            const cipher1 = EncryptionUtil.encryptWithAES(plaintext, key.data)
-            const cipher2 = EncryptionUtil.encryptWithAES(plaintext, key.data)
-            expect(cipher1.slice(0, INITIALIZATION_VECTOR_LENGTH)).not.toStrictEqual(cipher2.slice(0, INITIALIZATION_VECTOR_LENGTH))
-            expect(cipher1.slice(INITIALIZATION_VECTOR_LENGTH)).not.toStrictEqual(cipher2.slice(INITIALIZATION_VECTOR_LENGTH))
-        })
-    })
 
     describe('RSA', () => {
         it('returns a ciphertext which is different from the plaintext', async () => {
@@ -84,41 +48,6 @@ describe('EncryptionUtil', () => {
             const cipher1 = await EncryptionUtil.encryptForPublicKey(plaintext, key.getPublicKey(), AsymmetricEncryptionType.ML_KEM)
             const cipher2 = await EncryptionUtil.encryptForPublicKey(plaintext, key.getPublicKey(), AsymmetricEncryptionType.ML_KEM)
             expect(cipher1).not.toStrictEqual(cipher2)
-        })
-    })
-    
-    describe('StreamMessage decryption', () => {
-        it('passes the happy path', async () => {
-            const key = GroupKey.generate()
-            const nextKey = GroupKey.generate()
-            const streamMessage = await createMockMessage({
-                streamPartId: StreamPartIDUtils.parse('stream#0'),
-                publisher: await createTestWallet(),
-                content: {
-                    foo: 'bar'
-                },
-                encryptionKey: key,
-                nextEncryptionKey: nextKey
-            }) as StreamMessageAESEncrypted
-            const [content, newGroupKey] = EncryptionUtil.decryptStreamMessage(streamMessage, key)
-            expect(content).toEqualBinary(utf8ToBinary('{"foo":"bar"}'))
-            expect(newGroupKey).toEqual(nextKey)
-        })
-    
-        it('throws if newGroupKey invalid', async () => {
-            const key = GroupKey.generate()
-            const msg = await createMockMessage({
-                publisher: await createTestWallet(),
-                streamPartId: toStreamPartID(STREAM_ID, 0),
-                encryptionKey: key
-            })
-            const msg2 = new StreamMessage({
-                ...msg,
-                newGroupKey: { id: 'mockId', data: hexToBinary('0x1234') }
-            }) as StreamMessageAESEncrypted
-            expect(() => EncryptionUtil.decryptStreamMessage(msg2, key)).toThrowStreamrClientError(
-                new StreamrClientError('Could not decrypt new encryption key', 'DECRYPT_ERROR', msg2)
-            )
         })
     })
 })

--- a/packages/sdk/test/unit/Publisher.test.ts
+++ b/packages/sdk/test/unit/Publisher.test.ts
@@ -3,7 +3,7 @@ import { Publisher } from '../../src/publish/Publisher'
 import { MessageSigner } from '../../src/signature/MessageSigner'
 import { SignatureValidator } from '../../src/signature/SignatureValidator'
 import { StreamIDBuilder } from '../../src/StreamIDBuilder'
-import { createGroupKeyManager, createRandomIdentity } from '../test-utils/utils'
+import { createGroupKeyManager, createMockEncryptionService, createRandomIdentity } from '../test-utils/utils'
 import type { StrictStreamrClientConfig } from '../../src/ConfigTypes'
 
 describe('Publisher', () => {
@@ -22,6 +22,7 @@ describe('Publisher', () => {
             identity,
             mock<SignatureValidator>(),
             mock<MessageSigner>(),
+            createMockEncryptionService(),
             {
                 encryption: {},
                 validation: {

--- a/packages/sdk/test/unit/aesUtils.test.ts
+++ b/packages/sdk/test/unit/aesUtils.test.ts
@@ -20,7 +20,7 @@ describe('aesUtils', () => {
         it('returns the initial plaintext after decrypting the ciphertext', () => {
             const key = GroupKey.generate()
             const ciphertext = encryptWithAES(plaintext, key.data)
-            expect(decryptWithAES(ciphertext, key.data)).toStrictEqual(plaintext)
+            expect(decryptWithAES(ciphertext, key.data)).toEqualBinary(plaintext)
         })
     
         it('preserves size (plaintext + iv)', () => {

--- a/packages/sdk/test/unit/aesUtils.test.ts
+++ b/packages/sdk/test/unit/aesUtils.test.ts
@@ -1,0 +1,80 @@
+import { createTestWallet } from '@streamr/test-utils'
+import { StreamPartIDUtils, utf8ToBinary } from '@streamr/utils'
+import { decryptWithAES, encryptWithAES, INITIALIZATION_VECTOR_LENGTH } from '../../src/encryption/aesUtils'
+import { decryptStreamMessageContent } from '../../src/encryption/encryptionUtils'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { createMockMessage } from '../test-utils/utils'
+import { StreamMessageAESEncrypted } from './../../src/protocol/StreamMessage'
+
+describe('aesUtils', () => {
+
+    const plaintext = Buffer.from('some random text', 'utf8')
+
+    describe('encryptWithAES / decryptWithAES', () => {
+        it('returns a ciphertext which is different from the plaintext', () => {
+            const key = GroupKey.generate()
+            const ciphertext = encryptWithAES(plaintext, key.data)
+            expect(ciphertext).not.toStrictEqual(plaintext)
+        })
+
+        it('returns the initial plaintext after decrypting the ciphertext', () => {
+            const key = GroupKey.generate()
+            const ciphertext = encryptWithAES(plaintext, key.data)
+            expect(decryptWithAES(ciphertext, key.data)).toStrictEqual(plaintext)
+        })
+    
+        it('preserves size (plaintext + iv)', () => {
+            const key = GroupKey.generate()
+            const ciphertext = encryptWithAES(plaintext, key.data)
+            expect(ciphertext.length).toStrictEqual(plaintext.length + INITIALIZATION_VECTOR_LENGTH)
+        })
+    
+        it('produces different ivs and ciphertexts upon multiple encrypt() calls', () => {
+            const key = GroupKey.generate()
+            const cipher1 = encryptWithAES(plaintext, key.data)
+            const cipher2 = encryptWithAES(plaintext, key.data)
+            expect(cipher1.slice(0, INITIALIZATION_VECTOR_LENGTH)).not.toStrictEqual(cipher2.slice(0, INITIALIZATION_VECTOR_LENGTH))
+            expect(cipher1.slice(INITIALIZATION_VECTOR_LENGTH)).not.toStrictEqual(cipher2.slice(INITIALIZATION_VECTOR_LENGTH))
+        })
+    })
+    
+    describe('decryptStreamMessageContent', () => {
+        it('decrypts content and new group key', async () => {
+            const key = GroupKey.generate()
+            const nextKey = GroupKey.generate()
+            const streamMessage = await createMockMessage({
+                streamPartId: StreamPartIDUtils.parse('stream#0'),
+                publisher: await createTestWallet(),
+                content: {
+                    foo: 'bar'
+                },
+                encryptionKey: key,
+                nextEncryptionKey: nextKey
+            }) as StreamMessageAESEncrypted
+            const result = decryptStreamMessageContent(streamMessage.content, key.data, streamMessage.newGroupKey)
+            expect(result.content).toEqualBinary(utf8ToBinary('{"foo":"bar"}'))
+            const newGroupKey = result.newGroupKey 
+                ? new GroupKey(result.newGroupKey.id, Buffer.from(result.newGroupKey.data))
+                : undefined
+            expect(newGroupKey).toEqual(nextKey)
+        })
+    
+        it('throws if newGroupKey data is invalid', async () => {
+            const key = GroupKey.generate()
+            const streamMessage = await createMockMessage({
+                streamPartId: StreamPartIDUtils.parse('stream#0'),
+                publisher: await createTestWallet(),
+                content: { foo: 'bar' },
+                encryptionKey: key
+            }) as StreamMessageAESEncrypted
+            // Provide an invalid encrypted group key (too short to contain valid AES data)
+            const invalidNewGroupKey = { id: 'mockId', data: new Uint8Array([1, 2, 3, 4]) }
+            // decryptStreamMessageContent uses Node's crypto which throws on invalid cipher data
+            expect(() => decryptStreamMessageContent(
+                streamMessage.content, 
+                key.data, 
+                invalidNewGroupKey
+            )).toThrow()
+        })
+    })
+})

--- a/packages/sdk/test/unit/messagePipeline.test.ts
+++ b/packages/sdk/test/unit/messagePipeline.test.ts
@@ -6,15 +6,15 @@ import type { StrictStreamrClientConfig } from '../../src/ConfigTypes'
 import { DestroySignal } from '../../src/DestroySignal'
 import { ERC1271ContractFacade } from '../../src/contracts/ERC1271ContractFacade'
 import { StreamRegistry } from '../../src/contracts/StreamRegistry'
-import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
 import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { encryptWithAES } from '../../src/encryption/aesUtils'
 import { StreamrClientEventEmitter } from '../../src/events'
 import { SignatureValidator } from '../../src/signature/SignatureValidator'
 import { createMessagePipeline } from '../../src/subscribe/messagePipeline'
 import { PushPipeline } from '../../src/utils/PushPipeline'
-import { createMessageSigner, mockLoggerFactory } from '../test-utils/utils'
+import { createMessageSigner, createMockEncryptionService, mockLoggerFactory } from '../test-utils/utils'
 import { MessageID } from './../../src/protocol/MessageID'
 import { StreamMessage, StreamMessageType } from './../../src/protocol/StreamMessage'
 import { EncryptionType, ContentType, SignatureType } from '@streamr/trackerless-network'
@@ -95,6 +95,7 @@ describe('messagePipeline', () => {
                 new StreamrClientEventEmitter(),
                 destroySignal
             ),
+            encryptionService: createMockEncryptionService(),
             config,
             destroySignal,
             loggerFactory: mockLoggerFactory(),
@@ -163,7 +164,7 @@ describe('messagePipeline', () => {
 
     it('error: no encryption key available', async () => {
         const encryptionKey = GroupKey.generate()
-        const content = EncryptionUtil.encryptWithAES(Buffer.from(JSON.stringify(CONTENT), 'utf8'), encryptionKey.data)
+        const content = encryptWithAES(Buffer.from(JSON.stringify(CONTENT), 'utf8'), encryptionKey.data)
         await pipeline.push(await createMessage({
             content,
             encryptionType: EncryptionType.AES,

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -11,7 +11,14 @@ import { ResendRangeOptions } from '../../src/subscribe/Resends'
 import { Subscription, SubscriptionEvents } from '../../src/subscribe/Subscription'
 import { initResendSubscription } from '../../src/subscribe/resendSubscription'
 import { PushPipeline } from '../../src/utils/PushPipeline'
-import { createGroupKeyQueue, createMessageSigner, createRandomIdentity, createStreamRegistry, mockLoggerFactory } from '../test-utils/utils'
+import {
+    createGroupKeyQueue,
+    createMessageSigner,
+    createMockEncryptionService,
+    createRandomIdentity,
+    createStreamRegistry,
+    mockLoggerFactory
+} from '../test-utils/utils'
 import { StreamMessage } from './../../src/protocol/StreamMessage'
 import { createStrictConfig } from '../../src/Config'
 
@@ -61,6 +68,7 @@ describe('resend subscription', () => {
             groupKeyQueue: await createGroupKeyQueue(identity),
             signatureValidator: mock<SignatureValidator>(),
             messageSigner: createMessageSigner(identity),
+            encryptionService: createMockEncryptionService(),
             config: createStrictConfig(),
         })
     })

--- a/packages/utils/src/SigningUtil.ts
+++ b/packages/utils/src/SigningUtil.ts
@@ -82,8 +82,10 @@ export class EcdsaSecp256k1Evm extends SigningUtil {
     async createSignature(payload: Uint8Array, privateKey: Uint8Array): Promise<Uint8Array> {
         const msgHash = this.keccakHash(payload)
         const sigObj = secp256k1.ecdsaSign(msgHash, privateKey)
-        const result = Buffer.alloc(sigObj.signature.length + 1, Buffer.from(sigObj.signature))
-        result.writeInt8(27 + sigObj.recid, result.length - 1)
+        // Return plain Uint8Array (not Buffer) for proper serialization across environments
+        const result = new Uint8Array(sigObj.signature.length + 1)
+        result.set(sigObj.signature)
+        result[result.length - 1] = 27 + sigObj.recid
         return result
     }
 

--- a/packages/utils/src/binaryUtils.ts
+++ b/packages/utils/src/binaryUtils.ts
@@ -20,9 +20,12 @@ export const hexToBinary = (hex: string): Uint8Array => {
     if (hex.length % 2 !== 0) {
         throw new Error(`Hex string length must be even, received: 0x${hex}`)
     }
-    const result = Buffer.from(hex, 'hex')
-    if (hex.length !== result.length * 2) {
+    if (!/^[0-9a-fA-F]*$/.test(hex)) {
         throw new Error(`Hex string input is likely malformed, received: 0x${hex}`)
+    }
+    const result = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < result.length; i++) {
+        result[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
     }
     return result
 }

--- a/packages/utils/test/SigningUtil.test.ts
+++ b/packages/utils/test/SigningUtil.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { hexToBinary } from '../src/binaryUtils'
+import { areEqualBinaries, hexToBinary } from '../src/binaryUtils'
 import { EcdsaSecp256k1Evm, EcdsaSecp256r1, MlDsa87, SigningUtil } from '../src/SigningUtil'
 import { toUserId, toUserIdRaw } from '../src/UserID'
 
@@ -46,7 +46,9 @@ describe('EcdsaSecp256k1Evm', () => {
         it('produces correct signature', async () => {
             const payload = Buffer.from('data-to-sign')
             const signature = await util.createSignature(payload, privateKey)
-            expect(signature).toStrictEqual(hexToBinary('787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b'))
+
+            const expectedSignature = hexToBinary('787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
+            expect(areEqualBinaries(signature, expectedSignature)).toBeTrue()
         })
     })
     

--- a/packages/utils/test/SigningUtil.test.ts
+++ b/packages/utils/test/SigningUtil.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { areEqualBinaries, hexToBinary } from '../src/binaryUtils'
+import { hexToBinary } from '../src/binaryUtils'
 import { EcdsaSecp256k1Evm, EcdsaSecp256r1, MlDsa87, SigningUtil } from '../src/SigningUtil'
 import { toUserId, toUserIdRaw } from '../src/UserID'
 
@@ -46,9 +46,7 @@ describe('EcdsaSecp256k1Evm', () => {
         it('produces correct signature', async () => {
             const payload = Buffer.from('data-to-sign')
             const signature = await util.createSignature(payload, privateKey)
-
-            const expectedSignature = hexToBinary('787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
-            expect(areEqualBinaries(signature, expectedSignature)).toBeTrue()
+            expect(signature).toStrictEqual(hexToBinary('787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b'))
         })
     })
     


### PR DESCRIPTION
## Summary

Offload CPU-intensive AES-256-CTR encryption/decryption to a Web Worker using Comlink, improving main thread responsiveness during stream message processing. This PR also fixes several `Buffer` vs `Uint8Array` serialization issues that caused test failures on Linux CI due to inconsistent binary type handling across the worker boundary.

## Changes

### `@streamr/sdk`

- Add `EncryptionService` singleton with lazy worker initialization
- Add `EncryptionWorker` with handlers for encrypt, decrypt, and group key operations
- Extract low-level AES utilities to `aesUtils.ts` with `concatBytes()` helper to avoid `Buffer.concat()`
- Add platform-specific `createEncryptionWorker.ts` for browser/Node.js/Jest/Karma environments
- Update `MessageFactory` and `decrypt.ts` to use `EncryptionService`
- Simplify `EncryptionUtil.ts` to delegate to shared `aesUtils.ts`
- Fix `StreamMessageTranslator.ts` to convert protobuf binary fields (`signature`, `content`, `newGroupKey.data`) to plain `Uint8Array` after deserialization
- Add `createMockEncryptionService()` test utility for synchronous test execution
- Remove unused `EncryptionService.decryptWithAES` method

### `@streamr/utils`

- Fix `EcdsaSecp256k1Evm.createSignature()` to return plain `Uint8Array` instead of `Buffer`
- Fix `hexToBinary()` to return plain `Uint8Array` with upfront hex validation

## Watch Out

- **Test timeouts**: Worker loading adds latency on first encryption/decryption call. Tests that previously had tight timeouts may need adjustment. The key request timeout was bumped in this PR to accommodate worker initialization time.
- **Binary type consistency**: All public APIs now return `Uint8Array` as declared. Code that relied on `Buffer`-specific methods (like `.toString('hex')`) may need updates to use `binaryToHex()` or similar utilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message publish/decrypt paths and introduces worker-based crypto plus binary type conversions; failures could break encryption/decryption or cross-env serialization, though changes are mostly additive with good test coverage.
> 
> **Overview**
> Moves AES-256-CTR stream message encryption/decryption (including group key wrapping/unwrapping) off the main thread by introducing `EncryptionService` + a Comlink-exposed `EncryptionWorker`, and rewiring publish (`MessageFactory`) and subscribe (`decrypt`, `messagePipeline`) flows to use it.
> 
> Extracts shared AES primitives into `aesUtils.ts` and introduces `encryptionUtils.ts` request/response shapes for worker communication, while removing AES/group-key helpers from `EncryptionUtil`/`GroupKey` and narrowing `EncryptionUtil` to asymmetric key-exchange + ML-KEM wrapping.
> 
> Hardens cross-environment binary handling by normalizing protobuf `content`/`signature`/`newGroupKey.data` to plain `Uint8Array`, returning `Uint8Array` from `createSignature`, and reimplementing `hexToBinary` to validate input and avoid `Buffer`.
> 
> Updates build/test plumbing to bundle/alias the new worker across Node/browser/Jest/Karma, adds a synchronous `createMockEncryptionService()` for tests, and adjusts a key-request timeout to account for worker startup latency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3208dcaca31efb34c87cc7f245a19069e94506c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->